### PR TITLE
fix /image route for gravatar

### DIFF
--- a/packages/server/src/common/dto/index.ts
+++ b/packages/server/src/common/dto/index.ts
@@ -3,16 +3,17 @@ import { IsInt, IsNumber, IsOptional, IsString, IsUrl } from 'class-validator'
 import { APP_HOMEPAGE_URL } from '@environments'
 
 export class ImageResizingDto {
-  @IsUrl({
-    require_protocol: true,
-    host_whitelist: [
-      '127.0.0.1',
-      'localhost',
-      'images.unsplash.com',
-      'unsplash.com',
-      new URL(APP_HOMEPAGE_URL).hostname
-    ]
-  })
+	@IsUrl({
+		require_protocol: true,
+		host_whitelist: [
+			'127.0.0.1',
+			'localhost',
+			'secure.gravatar.com',
+			'images.unsplash.com',
+			'unsplash.com',
+			new URL(APP_HOMEPAGE_URL).hostname
+		]
+	})
   url: string
 
   @Transform(parseInt)


### PR DESCRIPTION
The /image does not allow to use gravatar (which is used by the user avatar) now. This PR fixes this.

<img width="765" alt="image" src="https://github.com/heyform/heyform/assets/11208082/5013d9cd-1c73-4f8d-9703-17a0eceac446">
