### PR TITLE
Adding ENVS and options for deailing with SSL email endpoints (port 465)

### DIFF
--- a/packages/server/src/config/smtp/index.ts
+++ b/packages/server/src/config/smtp/index.ts
@@ -1,4 +1,4 @@
-import { SMTP_HOST, SMTP_PASSWORD, SMTP_PORT, SMTP_USER } from '@environments'
+import { SMTP_HOST, SMTP_PASSWORD, SMTP_PORT, SMTP_USER, SMTP_SECURE, SMTP_IGNORE_CERT } from '@environments'
 import { SmtpOptions } from '@utils'
 
 export const SmtpOptionsFactory = (): SmtpOptions => ({
@@ -6,6 +6,8 @@ export const SmtpOptionsFactory = (): SmtpOptions => ({
   port: SMTP_PORT,
   user: SMTP_USER,
   password: SMTP_PASSWORD,
+  secure: SMTP_SECURE,
+  ignoreCert: SMTP_IGNORE_CERT,
   pool: true,
   logger: false
 })

--- a/packages/server/src/environments/index.ts
+++ b/packages/server/src/environments/index.ts
@@ -66,6 +66,8 @@ export const SMTP_HOST: string = process.env.SMTP_HOST
 export const SMTP_PORT: number = +process.env.SMTP_PORT
 export const SMTP_USER: string = process.env.SMTP_USER
 export const SMTP_PASSWORD: string = process.env.SMTP_PASSWORD
+export const SMTP_SECURE: boolean = process.env.SMTP_SECURE === "true" ? true : false
+export const SMTP_IGNORE_CERT: boolean = process.env.SMTP_IGNORE_CERT === "true" ? true : false
 
 // Google recaptcha
 export const GOOGLE_RECAPTCHA_KEY: string = process.env.GOOGLE_RECAPTCHA_KEY

--- a/packages/server/src/utils/smtp/index.ts
+++ b/packages/server/src/utils/smtp/index.ts
@@ -5,6 +5,8 @@ export interface SmtpOptions {
   port: number
   user: string
   password: string
+  secure: boolean
+  ignoreCert: boolean
   pool: boolean
   logger: any
 }
@@ -23,9 +25,13 @@ export async function smtpSendMail(
   const transport = nodemailer.createTransport({
     host: options.host,
     port: options.port,
+    secure: options.secure,
     auth: {
       user: options.user,
       pass: options.password
+    },
+    tls: {
+      rejectUnauthorized: options.ignoreCert,
     },
     pool: options.pool,
     logger: options.logger


### PR DESCRIPTION
This PR adds proper support for SSL based SMTP using nodemailer.  In particular this is required when using mail systems such as AWS SES.

This has been tested on our self hosted setup against AWS SES.