### PR TITLE
issue #112 link to local-development

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Interested in self-hosting HeyForm on your server? Take a look at the [self-host
 
 ## Local development
 
-Follow the [local installation instructions](https://docs.heyform.net/local-development) to run the project locally.
+Follow the [local installation instructions](https://docs.heyform.net/open-source/local-development) to run the project locally.
 
 ## How to Contribute
 You are awesome, let's build great software together. Head over to the [contribute docs](https://docs.heyform.net/contribute) to get started. 💪


### PR DESCRIPTION
docs: fix broken link in README

Corrected the link to the contributing guidelines section in the README file.
