### PR TITLE
Fix saving first hidden_field

### DIFF
--- a/packages/webapp/src/utils/hook.ts
+++ b/packages/webapp/src/utils/hook.ts
@@ -34,7 +34,8 @@ export function useQuery(options?: IMapType): IMapType {
   return useMemo(() => {
     const value = qs.parse(location.search, {
       decode: true,
-      separator: ','
+      separator: ',',
+      ignoreQueryPrefix: true
     })
 
     if (options) {


### PR DESCRIPTION
We are including the leading question mark from the query parameters. However, we missed to tell that to the qs library for parsing