### PR TITLE
Introducing HeyForm Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 
 <p align="center">
 <a href="https://trendshift.io/repositories/9025" target="_blank"><img src="https://trendshift.io/api/badge/repositories/9025" alt="heyform" style="width: 250px; height: 55px;" width="250" height="55"/></a>
-<a href="https://gurubase.io/g/heyform" target="_blank"><img src="https://img.shields.io/badge/Gurubase-Ask%20HeyForm%20Guru-006BFF" alt="Gurubase"/></a>
 </p>
 
 <img src="./assets/images/screenshot.png" alt="HeyForm" />
@@ -93,6 +92,7 @@ You'll find a lot of resources to help you get started with HeyForm in the [help
 
 - Have a question? Join the [Discord server](https://discord.gg/sgT4v4GSTe) and get instant help.
 - Found a bug? [Create an issue](https://github.com/heyform/heyform/issues/new/choose)
+- You can also [Ask HeyForm Guru](https://gurubase.io/g/heyform), it is a HeyForm-focused AI to answer your questions.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 <p align="center">
 <a href="https://trendshift.io/repositories/9025" target="_blank"><img src="https://trendshift.io/api/badge/repositories/9025" alt="heyform" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+<a href="https://gurubase.io/g/heyform" target="_blank"><img src="https://img.shields.io/badge/Gurubase-Ask%20HeyForm%20Guru-006BFF" alt="Gurubase"/></a>
 </p>
 
 <img src="./assets/images/screenshot.png" alt="HeyForm" />


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [HeyForm Guru](https://gurubase.io/g/heyform) to Gurubase. HeyForm Guru uses the data from this repo and data from the [docs](https://docs.heyform.net) to answer questions by leveraging the LLM.

In this PR, I showcased the "HeyForm Guru", which highlights that HeyForm now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable HeyForm Guru in Gurubase, just let me know that's totally fine.
