### PR TITLE
Update name localization for signup

### DIFF
--- a/packages/webapp/src/locales/en.ts
+++ b/packages/webapp/src/locales/en.ts
@@ -39,6 +39,7 @@ export default {
       signIn: 'sign in with existing one',
       signWith: 'Start with',
       continueWith: 'Or continue with',
+      Name: 'Name',
       nameCant: 'Name is required',
       invalidEmail: 'Invalid email address',
       PasswordViolation:

--- a/packages/webapp/src/locales/pl.ts
+++ b/packages/webapp/src/locales/pl.ts
@@ -41,6 +41,7 @@ export default {
       signIn: 'zaloguj się na istniejące konto',
       signWith: 'Zacznij z',
       continueWith: 'Lub kontynuuj z',
+      Name: 'Nazwa',
       nameCant: 'Nazwa jest wymagana',
       invalidEmail: 'Nieprawidłowy adres email',
       PasswordViolation:

--- a/packages/webapp/src/locales/tr.ts
+++ b/packages/webapp/src/locales/tr.ts
@@ -40,6 +40,7 @@ export default {
       signIn: 'mevcut hesapla giriş yap',
       signWith: 'İle başla',
       continueWith: 'Veya şununla devam et',
+      Name: 'İsim',
       nameCant: 'İsim gereklidir',
       invalidEmail: 'Geçersiz e-posta adresi',
       PasswordViolation:

--- a/packages/webapp/src/locales/zhTw.ts
+++ b/packages/webapp/src/locales/zhTw.ts
@@ -38,6 +38,7 @@ export default {
       signIn: '使用現有帳號登入',
       signWith: '使用以下方式開始',
       continueWith: '或者繼續使用',
+      Name: '名稱',
       nameCant: '名稱為必填',
       invalidEmail: '無效的電子郵件位址',
       PasswordViolation:


### PR DESCRIPTION
Problem:

![CleanShot 2024-11-18 at 20 35 33](https://github.com/user-attachments/assets/91d991ce-6a46-4298-8ca9-b569525fd7dd)

Added Name Field Translations:
English (en): "Name"
Polish (pl): "Nazwa"
Turkish (tr): "İsim"
Traditional Chinese (zhTw): "名稱"