### PR TITLE
Add TLS ServerName option

### DIFF
--- a/packages/server/src/config/smtp/index.ts
+++ b/packages/server/src/config/smtp/index.ts
@@ -4,7 +4,8 @@ import {
   SMTP_PORT,
   SMTP_USER,
   SMTP_SECURE,
-  SMTP_IGNORE_CERT
+  SMTP_IGNORE_CERT,
+  SMTP_SERVERNAME
 } from '@environments'
 import { SmtpOptions } from '@utils'
 
@@ -14,6 +15,7 @@ export const SmtpOptionsFactory = (): SmtpOptions => ({
   user: SMTP_USER,
   password: SMTP_PASSWORD,
   secure: SMTP_SECURE,
+  servername: SMTP_SERVERNAME,
   ignoreCert: SMTP_IGNORE_CERT,
   pool: true,
   logger: false

--- a/packages/server/src/environments/index.ts
+++ b/packages/server/src/environments/index.ts
@@ -66,6 +66,7 @@ export const SMTP_HOST: string = process.env.SMTP_HOST
 export const SMTP_PORT: number = +process.env.SMTP_PORT
 export const SMTP_USER: string = process.env.SMTP_USER
 export const SMTP_PASSWORD: string = process.env.SMTP_PASSWORD
+export const SMTP_SERVERNAME: string = process.env.SMTP_SERVERNAME || null
 export const SMTP_SECURE: boolean = helper.isTrue(process.env.SMTP_SECURE)
 export const SMTP_IGNORE_CERT: boolean = helper.isTrue(process.env.SMTP_IGNORE_CERT)
 

--- a/packages/server/src/utils/smtp/index.ts
+++ b/packages/server/src/utils/smtp/index.ts
@@ -6,6 +6,7 @@ export interface SmtpOptions {
   user: string
   password: string
   secure: boolean
+  servername: string
   ignoreCert: boolean
   pool: boolean
   logger: any
@@ -31,6 +32,7 @@ export async function smtpSendMail(
       pass: options.password
     },
     tls: {
+      servername: options.servername,
       rejectUnauthorized: options.ignoreCert
     },
     pool: options.pool,


### PR DESCRIPTION
Hello,  

I've encountered an issue with email sending in my setup. My mail server is running on the same host and is behind the same Traefik instance as my application. To address this, I needed to add an `extra_hosts` entry in the `docker-compose.yml` file to map the mailer hostname to the traefik IP address in `/etc/hosts`.  

However, I discovered that Nodemailer (the library used for sending emails) has a particular behavior when resolving hostnames. By default, it first performs a DNS lookup. If the DNS lookup fails, it falls back to the `/etc/hosts` file. This causes problems in my setup.  

According to the [Nodemailer documentation](https://github.com/nodemailer/nodemailer/blob/e70b9c18bd4ba14d500197fa1614ed37f5536446/README.md#i-have-issues-with-dns--hosts-file), the recommended fix is:  
1. Use the IP address directly as the `hostname`.  
2. Explicitly set the `tls.servername` option to the intended hostname.  

This pull request implements these changes, ensuring compatibility with setups like mine.  

Thank you for considering this update! Please let me know if you have any questions or need further clarification. 