### PR TITLE
fix: enable Spanish option

### DIFF
--- a/packages/server/src/queue/translate-form.queue.ts
+++ b/packages/server/src/queue/translate-form.queue.ts
@@ -18,6 +18,7 @@ interface TranslateFormQueueJob {
 
 const LANGUAGES = {
   en: 'English',
+  es: 'Spanish',
   de: 'German',
   fr: 'French',
 	pl: 'Polish',

--- a/packages/webapp/src/consts/formSettings.ts
+++ b/packages/webapp/src/consts/formSettings.ts
@@ -15,6 +15,10 @@ export const LOCALES_OPTIONS = [
     value: 'en'
   },
   {
+    label: 'Spanish',
+    value: 'es'
+  },
+  {
     label: 'Polski',
     value: 'pl'
   },
@@ -36,6 +40,10 @@ export const FORM_LOCALES_OPTIONS = [
   {
     label: 'English',
     value: 'en'
+  },
+  {
+    label: 'Spanish',
+    value: 'es'
   },
   {
     label: 'German',


### PR DESCRIPTION
The Spanish option was not shown in the language menu