### PR TITLE
Fix: Update 'Getting Started' link in sidebar to point to correct doc…

### DIFF
--- a/packages/webapp/src/components/sidebar/Navigation.tsx
+++ b/packages/webapp/src/components/sidebar/Navigation.tsx
@@ -116,7 +116,7 @@ export const Navigation: FC<NavigationProps> = observer(
           </h3>
           <div className="mt-1 space-y-1" aria-labelledby="resources-headline">
             <a
-              href="https://docs.heyform.net/create-your-first-heyform"
+              href="https://docs.heyform.net/quickstart/create-a-form"
               target="_blank"
               className="group flex items-center rounded-md px-2 py-1 text-sm text-slate-700 hover:bg-slate-200 hover:text-slate-900"
             >


### PR DESCRIPTION
 ### Fix broken documentation link

**What was fixed:**
Updated the outdated link from  `https://docs.heyform.net/create-your-first-heyform`  to  `https://docs.heyform.net/quickstart/create-a-form`  

**Why:**
The previous link redirected to empty page. This change ensures users are directed to the correct Quickstart page for form creation