### PR TITLE
fix: enable brazilian portuguese option

### DIFF
--- a/packages/server/src/queue/translate-form.queue.ts
+++ b/packages/server/src/queue/translate-form.queue.ts
@@ -20,6 +20,7 @@ const LANGUAGES = {
   en: 'English',
   de: 'German',
   fr: 'French',
+  'pt-br': 'Brazilian Portuguese',
 	pl: 'Polish',
   tr: 'Turkish',
   'zh-cn': 'Simplified Chinese',

--- a/packages/webapp/src/consts/formSettings.ts
+++ b/packages/webapp/src/consts/formSettings.ts
@@ -19,6 +19,10 @@ export const LOCALES_OPTIONS = [
     value: 'pl'
   },
   {
+    label: 'Português Brasileiro',
+    value: 'pt-br'
+  },
+  {
     label: 'Türkçe',
     value: 'tr'
   },
@@ -48,6 +52,10 @@ export const FORM_LOCALES_OPTIONS = [
   {
     label: 'Polish',
     value: 'pl'
+  },
+  {
+    label: 'Brazilian Portuguese',
+    value: 'pt-br'
   },
   {
     label: 'Turkish',


### PR DESCRIPTION
Brazilian Portuguese was not listed on language menus.