### PR TITLE
Fix Docker production web assets and bundle React in Vite build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,26 @@ COPY pnpm-workspace.yaml $APP_PATH/pnpm-workspace.yaml
 COPY packages/server $APP_PATH/packages/server
 RUN mkdir -p $APP_PATH/packages/server/static/upload
 COPY packages/webapp $APP_PATH/packages/webapp
-COPY packages/server/view/index.html $APP_PATH/packages/webapp/index.html
+COPY packages/answer-utils $APP_PATH/packages/answer-utils
+COPY packages/shared-types-enums $APP_PATH/packages/shared-types-enums
+COPY packages/utils $APP_PATH/packages/utils
+COPY packages/form-renderer $APP_PATH/packages/form-renderer
+COPY packages/embed $APP_PATH/packages/embed
 
+# Build process
 RUN pnpm install
 RUN pnpm build:server
 RUN pnpm build:webapp
-RUN pnpm --filter ./packages/webapp export
+
+# Copy webapp public assets and bundles to server static directory
+# Server mounts STATIC_DIR at /static, so files must live directly under $APP_PATH/packages/server/static
+RUN cp -r $APP_PATH/packages/webapp/dist/static/* $APP_PATH/packages/server/static/
+
+# Use the production-built HTML as the server view template, but keep server-side injection for config + locale
+RUN cp $APP_PATH/packages/webapp/dist/index.html $APP_PATH/packages/server/view/index.html
+RUN sed -i 's/const heyform = {};/const heyform = {{{json heyform}}};/' $APP_PATH/packages/server/view/index.html
+RUN sed -i 's/const heyform={};/const heyform = {{{json heyform}}};/' $APP_PATH/packages/server/view/index.html
+RUN sed -i "s/screenHeight: window.screen.height/screenHeight: window.screen.height, locale: '{{locale}}'/" $APP_PATH/packages/server/view/index.html
 
 FROM node:18.20.0-alpine3.19 AS runner
 

--- a/packages/webapp/vite.config.mts
+++ b/packages/webapp/vite.config.mts
@@ -36,7 +36,6 @@ export default ({ mode }: ConfigEnv) => {
       assetsDir: 'static',
       assetsInlineLimit: 0,
       rollupOptions: {
-        external: ['react', 'react-dom'],
         output: {
           manualChunks: {
             vendor: [


### PR DESCRIPTION
This PR fixes the broken production Docker deployment in v3.0.0-rc.1 where the dashboard loads with missing assets (404/MIME errors) and browsers may throw Failed to resolve module specifier "react".

**What was broken**

- /static/* assets (e.g. initial.css, manifest.webmanifest, index-*.js) were not available inside the production container, causing 404 responses and MIME type errors.
- The webapp build output could contain bare imports like import ... from "react" because react/react-dom were marked as Rollup externals, which browsers can’t resolve without an import map.

**Changes**

Dockerfile

- Removes the incorrect pnpm --filter ./packages/webapp export step.
- Copies packages/webapp/dist/static/* into the server static directory so /static/* requests resolve correctly.
- Uses the production-built packages/webapp/dist/index.html as packages/server/view/index.html while keeping server-side config/locale injection.

packages/webapp/vite.config.mts

- Removes rollupOptions.external: ['react', 'react-dom'] so React is bundled and no bare module specifiers are left in the browser.

**How to verify**

- GET /static/initial.css returns 200 with Content-Type: text/css
- GET /static/manifest.webmanifest returns 200
- The rendered HTML no longer references main.tsx and instead loads index-*.js from /static/
- No 404/MIME errors and no "react" module specifier errors in the browser console