### PR TITLE
feat: disable email/password authentication to enforce SSO/Social only login

### DIFF
--- a/packages/server/src/controller/dashboard.controller.ts
+++ b/packages/server/src/controller/dashboard.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Get, Header, Res } from '@nestjs/common'
 import { Response } from 'express'
 
 import {
+  APP_DISABLE_EMAIL_LOGIN,
   APP_DISABLE_REGISTRATION,
   APP_HOMEPAGE_URL,
   COOKIE_DOMAIN,
@@ -23,7 +24,8 @@ export class DashboardController {
       enableGoogleFonts: ENABLE_GOOGLE_FONTS,
       stripePublishableKey: STRIPE_PUBLISHABLE_KEY,
       googleRecaptchaKey: GOOGLE_RECAPTCHA_KEY,
-      verifyEmailResendCooldownSeconds: Math.ceil(hs(VERIFY_EMAIL_RESEND_COOLDOWN) / 1000)
+      verifyEmailResendCooldownSeconds: Math.ceil(hs(VERIFY_EMAIL_RESEND_COOLDOWN) / 1000),
+      disableEmailLogin: APP_DISABLE_EMAIL_LOGIN
     }
   }
 

--- a/packages/server/src/environments/index.ts
+++ b/packages/server/src/environments/index.ts
@@ -23,6 +23,7 @@ export const APP_LISTEN_HOSTNAME: string = process.env.APP_LISTEN_HOSTNAME || '0
 export const APP_HOMEPAGE_URL: string =
   process.env.APP_HOMEPAGE_URL || `http://${APP_LISTEN_HOSTNAME}:${APP_LISTEN_PORT}`
 export const APP_DISABLE_REGISTRATION: boolean = helper.isTrue(process.env.APP_DISABLE_REGISTRATION)
+export const APP_DISABLE_EMAIL_LOGIN: boolean = helper.isTrue(process.env.APP_DISABLE_EMAIL_LOGIN)
 export const ENABLE_GOOGLE_FONTS: boolean =
   process.env.ENABLE_GOOGLE_FONTS === undefined
     ? true

--- a/packages/server/src/resolver/auth/login.resolver.ts
+++ b/packages/server/src/resolver/auth/login.resolver.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, UseGuards } from '@nestjs/common'
 
 import { GraphqlRequest, GraphqlResponse } from '@decorator'
+import { APP_DISABLE_EMAIL_LOGIN } from '@environments'
 import { LoginInput } from '@graphql'
 import { DeviceIdGuard } from '@guard'
 import { date, helper } from '@heyform-inc/utils'
@@ -25,6 +26,10 @@ export class LoginResolver {
     @GraphqlResponse() res: any,
     @Args('input') input: LoginInput
   ): Promise<boolean> {
+    if (APP_DISABLE_EMAIL_LOGIN) {
+      throw new BadRequestException('Email login is disabled.')
+    }
+
     const user = await this.userService.findByEmail(input.email)
 
     if (helper.isEmpty(user)) {

--- a/packages/server/src/resolver/auth/sign-up.resolver.ts
+++ b/packages/server/src/resolver/auth/sign-up.resolver.ts
@@ -1,7 +1,7 @@
 import { BadRequestException, UseGuards } from '@nestjs/common'
 
 import { GraphqlResponse } from '@decorator'
-import { APP_DISABLE_REGISTRATION, BCRYPT_SALT } from '@environments'
+import { APP_DISABLE_EMAIL_LOGIN, APP_DISABLE_REGISTRATION, BCRYPT_SALT } from '@environments'
 import { SignUpInput } from '@graphql'
 import { DeviceIdGuard } from '@guard'
 import { helper } from '@heyform-inc/utils'
@@ -26,7 +26,7 @@ export class SignUpResolver {
     @GraphqlResponse() res: any,
     @Args('input') input: SignUpInput
   ): Promise<boolean> {
-    if (APP_DISABLE_REGISTRATION) {
+    if (APP_DISABLE_REGISTRATION || APP_DISABLE_EMAIL_LOGIN) {
       throw new BadRequestException('Error: Registration is disabled')
     }
 

--- a/packages/webapp/src/consts/env.ts
+++ b/packages/webapp/src/consts/env.ts
@@ -22,6 +22,9 @@ export const STRIPE_PUBLISHABLE_KEY =
 export const GOOGLE_RECAPTCHA_KEY =
   window.heyform?.googleRecaptchaKey || (import.meta.env.VITE_GOOGLE_RECAPTCHA_KEY as string)
 
+export const DISABLE_EMAIL_LOGIN = helper.isTrue(
+  window.heyform?.disableEmailLogin ?? import.meta.env.VITE_DISABLE_EMAIL_LOGIN ?? 'false'
+)
 export const DISABLE_LOGIN_WITH_GOOGLE = helper.isTrue(
   window.heyform?.disableLoginWithGoogle || import.meta.env.VITE_DISABLE_LOGIN_WITH_GOOGLE
 )

--- a/packages/webapp/src/pages/auth/Login.tsx
+++ b/packages/webapp/src/pages/auth/Login.tsx
@@ -5,7 +5,7 @@ import { AuthService } from '@/services'
 import { useRouter } from '@/utils'
 
 import { Form, Input } from '@/components'
-import { isRegistrationDisabled } from '@/consts'
+import { DISABLE_EMAIL_LOGIN, isRegistrationDisabled } from '@/consts'
 
 import SocialLogin from './SocialLogin'
 
@@ -43,7 +43,7 @@ const Login = () => {
 
       <SocialLogin />
 
-      <Form.Simple
+      {!DISABLE_EMAIL_LOGIN && <Form.Simple
         className="space-y-4"
         fetch={fetch}
         submitProps={{
@@ -87,7 +87,7 @@ const Login = () => {
         >
           <Input.Password />
         </Form.Item>
-      </Form.Simple>
+      </Form.Simple>}
     </div>
   )
 }

--- a/packages/webapp/src/pages/auth/SocialLogin.tsx
+++ b/packages/webapp/src/pages/auth/SocialLogin.tsx
@@ -6,7 +6,8 @@ import { getDeviceId, useRouter } from '@/utils'
 
 import IconGoogle from '@/assets/google.svg?react'
 import { Button, Divider } from '@/components'
-import { DISABLE_LOGIN_WITH_APPLE, DISABLE_LOGIN_WITH_GOOGLE } from '@/consts'
+import { DISABLE_EMAIL_LOGIN, DISABLE_LOGIN_WITH_APPLE, DISABLE_LOGIN_WITH_GOOGLE } from '@/consts'
+
 
 interface SocialLoginProps {
   isSignUp?: boolean
@@ -80,7 +81,7 @@ const SocialLogin: FC<SocialLoginProps> = () => {
         ))}
       </div>
 
-      <Divider>{t('login.continueWith')}</Divider>
+      {!DISABLE_EMAIL_LOGIN && <Divider>{t('login.continueWith')}</Divider>}
     </>
   )
 }


### PR DESCRIPTION
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

In environments where authentication should be handled exclusively through an external identity provider, email/password login and registration need to be fully disabled without blocking social account provisioning on first login.
This PR introduces the `APP_DISABLE_EMAIL_LOGIN` environment variable to disable email-based authentication across the stack while leaving social login flows unaffected.

A follow-up PR will add generic OIDC support (openid-client) to enable integration with any standards-compliant identity provider such as Authelia, Keycloak, or similar, completing the SSO-only authentication setup.