### PR TITLE
fix: Mongoose validation error on numeric enum fields due to TypeScript reverse mappings

### DIFF
--- a/packages/server/src/model/app.model.ts
+++ b/packages/server/src/model/app.model.ts
@@ -77,7 +77,7 @@ export class AppModel extends Document {
   @Prop({
     type: Number,
     required: true,
-    enum: Object.values(AppStatusEnum)
+    enum: Object.values(AppStatusEnum).filter(v => typeof v === 'number')
   })
   status: AppStatusEnum
 }

--- a/packages/server/src/model/attachment.model.ts
+++ b/packages/server/src/model/attachment.model.ts
@@ -29,7 +29,7 @@ export class AttachmentModel extends Document {
   @Prop({
     type: Number,
     required: true,
-    enum: Object.values(AttachmentStatusEnum),
+    enum: Object.values(AttachmentStatusEnum).filter(v => typeof v === 'number'),
     default: AttachmentStatusEnum.PUBLIC
   })
   status: AttachmentStatusEnum

--- a/packages/server/src/model/form.model.ts
+++ b/packages/server/src/model/form.model.ts
@@ -43,7 +43,7 @@ export class FormModel extends Document {
   @Prop({
     type: Number,
     required: true,
-    enum: Object.values(InteractiveModeEnum),
+    enum: Object.values(InteractiveModeEnum).filter(v => typeof v === 'number'),
     default: InteractiveModeEnum.GENERAL
   })
   interactiveMode: InteractiveModeEnum
@@ -51,7 +51,7 @@ export class FormModel extends Document {
   @Prop({
     type: Number,
     required: true,
-    enum: Object.values(FormKindEnum),
+    enum: Object.values(FormKindEnum).filter(v => typeof v === 'number'),
     default: FormKindEnum.SURVEY
   })
   kind: FormKindEnum
@@ -110,7 +110,7 @@ export class FormModel extends Document {
   @Prop({
     type: Number,
     required: true,
-    enum: Object.values(FormStatusEnum),
+    enum: Object.values(FormStatusEnum).filter(v => typeof v === 'number'),
     default: FormStatusEnum.NORMAL
   })
   status: FormStatusEnum

--- a/packages/server/src/model/integration.model.ts
+++ b/packages/server/src/model/integration.model.ts
@@ -26,7 +26,7 @@ export class IntegrationModel extends Document {
   @Prop({
     type: Number,
     required: true,
-    enum: Object.values(IntegrationStatusEnum),
+    enum: Object.values(IntegrationStatusEnum).filter(v => typeof v === 'number'),
     default: IntegrationStatusEnum.ACTIVE
   })
   status: IntegrationStatusEnum

--- a/packages/server/src/model/submission.model.ts
+++ b/packages/server/src/model/submission.model.ts
@@ -57,7 +57,7 @@ export class SubmissionModel extends Document {
   @Prop({
     type: Number,
     required: true,
-    enum: Object.values(SubmissionStatusEnum),
+    enum: Object.values(SubmissionStatusEnum).filter(v => typeof v === 'number'),
     default: SubmissionStatusEnum.PUBLIC
   })
   status: SubmissionStatusEnum

--- a/packages/server/src/model/team-activity.model.ts
+++ b/packages/server/src/model/team-activity.model.ts
@@ -30,7 +30,7 @@ export class TeamActivityModel extends Document {
   @Prop({
     type: Number,
     required: true,
-    enum: Object.values(TeamActivityKindEnum)
+    enum: Object.values(TeamActivityKindEnum).filter(v => typeof v === 'number')
   })
   kind: TeamActivityKindEnum
 

--- a/packages/server/src/model/team-member.model.ts
+++ b/packages/server/src/model/team-member.model.ts
@@ -16,7 +16,7 @@ export class TeamMemberModel extends Document {
   @Prop({ required: true, index: true })
   memberId: string
 
-  @Prop({ type: Number, required: true, enum: Object.values(TeamRoleEnum) })
+  @Prop({ type: Number, required: true, enum: Object.values(TeamRoleEnum).filter(v => typeof v === 'number') })
   role: TeamRoleEnum
 
   @Prop({ default: 0 })

--- a/packages/server/src/model/template.model.ts
+++ b/packages/server/src/model/template.model.ts
@@ -29,7 +29,7 @@ export class TemplateModel extends Document {
   @Prop({
     type: Number,
     required: true,
-    enum: Object.values(InteractiveModeEnum),
+    enum: Object.values(InteractiveModeEnum).filter(v => typeof v === 'number'),
     default: InteractiveModeEnum.GENERAL
   })
   interactiveMode: InteractiveModeEnum
@@ -37,7 +37,7 @@ export class TemplateModel extends Document {
   @Prop({
     type: Number,
     required: true,
-    enum: Object.values(FormKindEnum),
+    enum: Object.values(FormKindEnum).filter(v => typeof v === 'number'),
     default: FormKindEnum.SURVEY
   })
   kind: FormKindEnum


### PR DESCRIPTION
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

⚠️ I am not confident this is the correct fix — the root cause may lie elsewhere (e.g. how values are serialized through GraphQL or passed by the client). This fix resolves the immediate validation errors...
