### PR TITLE
feat(branding): add APP_REMOVE_BRANDING env and fix UI setting

### DIFF
--- a/packages/server/src/common/graphql/form.graphql.ts
+++ b/packages/server/src/common/graphql/form.graphql.ts
@@ -987,6 +987,9 @@ export class FormSettingType {
 
   @Field({ nullable: true })
   enableEmailNotification?: boolean
+
+  @Field({ nullable: true })
+  removeBranding?: boolean
 }
 
 @ObjectType()

--- a/packages/server/src/environments/index.ts
+++ b/packages/server/src/environments/index.ts
@@ -23,6 +23,7 @@ export const APP_LISTEN_HOSTNAME: string = process.env.APP_LISTEN_HOSTNAME || '0
 export const APP_HOMEPAGE_URL: string =
   process.env.APP_HOMEPAGE_URL || `http://${APP_LISTEN_HOSTNAME}:${APP_LISTEN_PORT}`
 export const APP_DISABLE_REGISTRATION: boolean = helper.isTrue(process.env.APP_DISABLE_REGISTRATION)
+export const APP_REMOVE_BRANDING: boolean = helper.isTrue(process.env.APP_REMOVE_BRANDING)
 export const ENABLE_GOOGLE_FONTS: boolean =
   process.env.ENABLE_GOOGLE_FONTS === undefined
     ? true

--- a/packages/server/src/resolver/team/create-team.resolver.ts
+++ b/packages/server/src/resolver/team/create-team.resolver.ts
@@ -1,5 +1,6 @@
 import { Auth, User } from '@decorator'
 import { CreateTeamInput } from '@graphql'
+import { APP_REMOVE_BRANDING } from '@environments'
 import { TeamRoleEnum, UserModel } from '@model'
 import { Args, Mutation, Resolver } from '@nestjs/graphql'
 import { ProjectService, TeamService } from '@service'
@@ -21,7 +22,8 @@ export class CreateTeamResolver {
       ownerId: user.id,
       name: input.name,
       avatar: input.avatar,
-      storageQuota: 0
+      storageQuota: 0,
+      removeBranding: APP_REMOVE_BRANDING
     })
 
     await this.teamService.createMember({

--- a/packages/webapp/src/consts/gql.ts
+++ b/packages/webapp/src/consts/gql.ts
@@ -1423,6 +1423,7 @@ export const PUBLIC_FORM_GQL = gql`
         enableClosedMessage
         closedFormTitle
         closedFormDescription
+        removeBranding
       }
       drafts {
         id


### PR DESCRIPTION
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Add server-side support for removing the HeyForm branding via environment
variable, and fix the existing removeBranding setting that was non-functional
in the web UI.