### PR TITLE
feat(server): localize transactional emails for Brazilian Portuguese

### DIFF
--- a/packages/server/resources/email-templates/pt-br/account_deletion_alert.html
+++ b/packages/server/resources/email-templates/pt-br/account_deletion_alert.html
@@ -1,0 +1,10 @@
+---
+title: Sua conta HeyForm foi excluída
+---
+
+<p>Sua conta HeyForm foi excluída. Processamos a solicitação de exclusão da sua conta.</p>
+
+<p>
+  Todos os dados, incluindo conta, espaços de trabalho, projetos, formulários e envios, foram
+  excluídos permanentemente.
+</p>

--- a/packages/server/resources/email-templates/pt-br/account_deletion_request.html
+++ b/packages/server/resources/email-templates/pt-br/account_deletion_request.html
@@ -1,0 +1,12 @@
+---
+title: Verifique a solicitação de exclusão da sua conta HeyForm
+---
+
+<p>
+  Sentimos muito pela sua saída. Você solicitou a exclusão da sua conta HeyForm. O código de
+  verificação para prosseguir com a solicitação de exclusão é
+</p>
+
+<p style="font-weight: bold">
+  <code>{code}</code>
+</p>

--- a/packages/server/resources/email-templates/pt-br/account_deletion_request.html
+++ b/packages/server/resources/email-templates/pt-br/account_deletion_request.html
@@ -3,8 +3,8 @@ title: Verifique a solicitação de exclusão da sua conta HeyForm
 ---
 
 <p>
-  Sentimos muito pela sua saída. Você solicitou a exclusão da sua conta HeyForm. O código de
-  verificação para prosseguir com a solicitação de exclusão é
+  Que pena ver você ir embora. Você solicitou a exclusão da sua conta HeyForm. Use o código abaixo
+  para confirmar a solicitação:
 </p>
 
 <p style="font-weight: bold">

--- a/packages/server/resources/email-templates/pt-br/email_verification_request.html
+++ b/packages/server/resources/email-templates/pt-br/email_verification_request.html
@@ -1,0 +1,12 @@
+---
+title: Verifique seu endereço de email do HeyForm
+---
+
+<p>
+  Para continuar configurando sua conta HeyForm, precisamos confirmar seu endereço de email. Insira
+  este código no seu navegador.
+</p>
+
+<p style="font-weight: bold">
+  <code>{code}</code>
+</p>

--- a/packages/server/resources/email-templates/pt-br/email_verification_request.html
+++ b/packages/server/resources/email-templates/pt-br/email_verification_request.html
@@ -1,9 +1,9 @@
 ---
-title: Verifique seu endereço de email do HeyForm
+title: Verifique seu endereço de e-mail do HeyForm
 ---
 
 <p>
-  Para continuar configurando sua conta HeyForm, precisamos confirmar seu endereço de email. Insira
+  Para continuar configurando sua conta HeyForm, precisamos confirmar seu endereço de e-mail. Insira
   este código no seu navegador.
 </p>
 

--- a/packages/server/resources/email-templates/pt-br/password_change_alert.html
+++ b/packages/server/resources/email-templates/pt-br/password_change_alert.html
@@ -1,0 +1,9 @@
+---
+title: Sua senha do HeyForm foi atualizada
+---
+
+<p>Sua senha do HeyForm foi alterada.</p>
+<p>
+  Se você não fez essa alteração ou acredita que uma pessoa não autorizada acessou sua conta, acesse
+  o painel imediatamente para redefinir sua senha.
+</p>

--- a/packages/server/resources/email-templates/pt-br/project_deletion_alert.html
+++ b/packages/server/resources/email-templates/pt-br/project_deletion_alert.html
@@ -3,7 +3,7 @@ title: Seu projeto HeyForm foi excluído
 ---
 
 <p>
-  Este email confirma que o projeto <span style="font-weight: bold">{projectName}</span> foi
+  Este e-mail confirma que o projeto <span style="font-weight: bold">{projectName}</span> foi
   excluído do espaço de trabalho <span style="font-weight: bold">{teamName}</span> por
   <span style="font-weight: bold">{userName}</span>.
 </p>

--- a/packages/server/resources/email-templates/pt-br/project_deletion_alert.html
+++ b/packages/server/resources/email-templates/pt-br/project_deletion_alert.html
@@ -1,0 +1,14 @@
+---
+title: Seu projeto HeyForm foi excluído
+---
+
+<p>
+  Este email confirma que o projeto <span style="font-weight: bold">{projectName}</span> foi
+  excluído do espaço de trabalho <span style="font-weight: bold">{teamName}</span> por
+  <span style="font-weight: bold">{userName}</span>.
+</p>
+
+<p>
+  Todos os formulários e envios associados ao projeto
+  <span style="font-weight: bold">{projectName}</span> foram excluídos do sistema.
+</p>

--- a/packages/server/resources/email-templates/pt-br/project_deletion_request.html
+++ b/packages/server/resources/email-templates/pt-br/project_deletion_request.html
@@ -1,0 +1,12 @@
+---
+title: Verifique a solicitação de exclusão do projeto
+---
+
+<p>
+  Você solicitou a exclusão do projeto <span style="font-weight: bold">{projectName}</span> do
+  espaço de trabalho <span style="font-weight: bold">{teamName}</span>. O código de verificação para
+  prosseguir com a solicitação de exclusão é
+</p>
+<p>
+  <span style="font-weight: bold">{code}</span>
+</p>

--- a/packages/server/resources/email-templates/pt-br/project_deletion_request.html
+++ b/packages/server/resources/email-templates/pt-br/project_deletion_request.html
@@ -4,8 +4,8 @@ title: Verifique a solicitação de exclusão do projeto
 
 <p>
   Você solicitou a exclusão do projeto <span style="font-weight: bold">{projectName}</span> do
-  espaço de trabalho <span style="font-weight: bold">{teamName}</span>. O código de verificação para
-  prosseguir com a solicitação de exclusão é
+  espaço de trabalho <span style="font-weight: bold">{teamName}</span>. Use o código abaixo para
+  confirmar a solicitação:
 </p>
 <p>
   <span style="font-weight: bold">{code}</span>

--- a/packages/server/resources/email-templates/pt-br/schedule_account_deletion_alert.html
+++ b/packages/server/resources/email-templates/pt-br/schedule_account_deletion_alert.html
@@ -1,0 +1,16 @@
+---
+title: Você agendou a exclusão da sua conta HeyForm
+---
+
+<p>
+  Recebemos a solicitação de exclusão da sua conta HeyForm. Nosso sistema excluirá permanentemente
+  todos os seus dados, incluindo conta, espaços de trabalho, projetos, formulários e envios, em 48
+  horas.
+</p>
+<p>A exclusão foi solicitada por <strong>{fullName} ({email})</strong>.</p>
+<p>
+  Mudou de ideia? Acesse sua conta HeyForm e selecione a opção
+  <strong>Cancelar exclusão agendada</strong>. Você deve fazer isso em até 48 horas após a
+  solicitação para evitar a perda permanente dos dados.
+</p>
+<p>Observação: após a exclusão, o HeyForm não poderá recuperar seus dados.</p>

--- a/packages/server/resources/email-templates/pt-br/submission_notification.html
+++ b/packages/server/resources/email-templates/pt-br/submission_notification.html
@@ -1,0 +1,13 @@
+---
+title: Novo envio recebido em {formName}
+---
+
+<p>Você recebeu um novo envio de formulário. Confira os dados:</p>
+
+<div>
+  {submission}
+
+  <p>
+    <a href="{link}">Ver todos os envios</a>
+  </p>
+</div>

--- a/packages/server/resources/email-templates/pt-br/team_deletion_alert.html
+++ b/packages/server/resources/email-templates/pt-br/team_deletion_alert.html
@@ -3,6 +3,6 @@ title: Seu espaço de trabalho HeyForm foi excluído
 ---
 
 <p>
-  Este email confirma que o espaço de trabalho '{teamName}' foi excluído por '{userName}'. Os
+  Este e-mail confirma que o espaço de trabalho '{teamName}' foi excluído por '{userName}'. Os
   projetos, formulários e envios desse espaço de trabalho foram excluídos do sistema.
 </p>

--- a/packages/server/resources/email-templates/pt-br/team_deletion_alert.html
+++ b/packages/server/resources/email-templates/pt-br/team_deletion_alert.html
@@ -1,0 +1,8 @@
+---
+title: Seu espaço de trabalho HeyForm foi excluído
+---
+
+<p>
+  Este email confirma que o espaço de trabalho '{teamName}' foi excluído por '{userName}'. Os
+  projetos, formulários e envios desse espaço de trabalho foram excluídos do sistema.
+</p>

--- a/packages/server/resources/email-templates/pt-br/team_deletion_request.html
+++ b/packages/server/resources/email-templates/pt-br/team_deletion_request.html
@@ -3,8 +3,8 @@ title: Verifique a solicitação de exclusão do espaço de trabalho HeyForm
 ---
 
 <p>
-  Você solicitou a exclusão do espaço de trabalho HeyForm {teamName}. O código de verificação para
-  prosseguir com a solicitação de exclusão é
+  Você solicitou a exclusão do espaço de trabalho HeyForm {teamName}. Use o código abaixo para
+  confirmar a solicitação:
 </p>
 <p>
   <span style="font-weight: bold">{code}</span>

--- a/packages/server/resources/email-templates/pt-br/team_deletion_request.html
+++ b/packages/server/resources/email-templates/pt-br/team_deletion_request.html
@@ -1,0 +1,11 @@
+---
+title: Verifique a solicitação de exclusão do espaço de trabalho HeyForm
+---
+
+<p>
+  Você solicitou a exclusão do espaço de trabalho HeyForm {teamName}. O código de verificação para
+  prosseguir com a solicitação de exclusão é
+</p>
+<p>
+  <span style="font-weight: bold">{code}</span>
+</p>

--- a/packages/server/resources/email-templates/pt-br/team_invitation.html
+++ b/packages/server/resources/email-templates/pt-br/team_invitation.html
@@ -1,0 +1,13 @@
+---
+title: {userName} convidou você para o espaço de trabalho '{teamName}'
+---
+
+<p>{userName} convidou você para colaborar no espaço de trabalho {teamName}.</p>
+<p>
+  <a href="{link}">Ver convite</a>
+</p>
+<p>Este convite expira em 7 dias.</p>
+<p>
+  Observação: este convite foi enviado para {email}. Se você não esperava este convite, ignore este
+  email.
+</p>

--- a/packages/server/resources/email-templates/pt-br/team_invitation.html
+++ b/packages/server/resources/email-templates/pt-br/team_invitation.html
@@ -9,5 +9,5 @@ title: {userName} convidou você para o espaço de trabalho '{teamName}'
 <p>Este convite expira em 7 dias.</p>
 <p>
   Observação: este convite foi enviado para {email}. Se você não esperava este convite, ignore este
-  email.
+  e-mail.
 </p>

--- a/packages/server/src/common/graphql/user.graphql.ts
+++ b/packages/server/src/common/graphql/user.graphql.ts
@@ -26,6 +26,10 @@ export class UpdateUserInput {
   @Field({ nullable: true })
   @IsOptional()
   restoreGravatar?: boolean
+
+  @Field({ nullable: true })
+  @IsOptional()
+  lang?: UserLangEnum
 }
 
 @InputType()

--- a/packages/server/src/model/user.model.ts
+++ b/packages/server/src/model/user.model.ts
@@ -3,6 +3,7 @@ import { Document } from 'mongoose'
 
 export enum UserLangEnum {
   EN = 'en',
+  PT_BR = 'pt-br',
   ZH_CN = 'zh-cn'
 }
 

--- a/packages/server/src/queue/submission-notification.queue.ts
+++ b/packages/server/src/queue/submission-notification.queue.ts
@@ -28,10 +28,14 @@ export class SubmissionNotificationQueue extends BaseQueue {
     const user = await this.userService.findById(form.memberId)
     const html = answersToHtml(submission.answers)
 
-    await this.mailService.submissionNotification(user.email, {
-      formName: form.name,
-      submission: html,
-      link: `${APP_HOMEPAGE_URL}/workspace/${form.teamId}/project/${form.projectId}/form/${form.id}/submissions`
-    })
+    await this.mailService.submissionNotification(
+      user.email,
+      {
+        formName: form.name,
+        submission: html,
+        link: `${APP_HOMEPAGE_URL}/workspace/${form.teamId}/project/${form.projectId}/form/${form.id}/submissions`
+      },
+      user.lang
+    )
   }
 }

--- a/packages/server/src/resolver/auth/reset-password.resolver.ts
+++ b/packages/server/src/resolver/auth/reset-password.resolver.ts
@@ -45,7 +45,7 @@ export class ResetPasswordResolver {
     })
 
     await this.authService.invalidateSessions(user.id)
-    this.mailService.passwordChangeAlert(user.email)
+    this.mailService.passwordChangeAlert(user.email, lang)
 
     return true
   }

--- a/packages/server/src/resolver/auth/send-reset-password-email.resolver.ts
+++ b/packages/server/src/resolver/auth/send-reset-password-email.resolver.ts
@@ -36,7 +36,7 @@ export class SendResetPasswordEmailResolver {
     const key = `reset_password:${user.id}`
     const code = await this.authService.getVerificationCodeWithRateLimit(key)
 
-    this.mailService.emailVerificationRequest(input.email, code)
+    this.mailService.emailVerificationRequest(input.email, code, user.lang)
     return true
   }
 }

--- a/packages/server/src/resolver/auth/sign-up.resolver.ts
+++ b/packages/server/src/resolver/auth/sign-up.resolver.ts
@@ -63,7 +63,7 @@ export class SignUpResolver {
     })
 
     const code = await this.authService.getVerificationCodeWithRateLimit(`verify_email:${userId}`)
-    this.mailService.emailVerificationRequest(input.email, code)
+    this.mailService.emailVerificationRequest(input.email, code, client.lang)
 
     return true
   }

--- a/packages/server/src/resolver/project/delete-project-code.resolver.ts
+++ b/packages/server/src/resolver/project/delete-project-code.resolver.ts
@@ -29,11 +29,15 @@ export class DeleteProjectCodeResolver {
     const key = `verify_delete_project:${project.id}`
     const code = await this.authService.getVerificationCode(key)
 
-    this.mailService.projectDeletionRequest(user.email, {
-      teamName: team.name,
-      projectName: project.name,
-      code
-    })
+    this.mailService.projectDeletionRequest(
+      user.email,
+      {
+        teamName: team.name,
+        projectName: project.name,
+        code
+      },
+      user.lang
+    )
 
     return true
   }

--- a/packages/server/src/resolver/project/delete-project.resolver.ts
+++ b/packages/server/src/resolver/project/delete-project.resolver.ts
@@ -36,11 +36,15 @@ export class DeleteProjectResolver {
 
     await this.projectService.delete(input.projectId)
 
-    this.mailService.projectDeletionAlert(user.email, {
-      teamName: team.name,
-      projectName: project.name,
-      userName: user.name
-    })
+    this.mailService.projectDeletionAlert(
+      user.email,
+      {
+        teamName: team.name,
+        projectName: project.name,
+        userName: user.name
+      },
+      user.lang
+    )
 
     return true
   }

--- a/packages/server/src/resolver/team/dissolve-team-code.resolver.ts
+++ b/packages/server/src/resolver/team/dissolve-team-code.resolver.ts
@@ -28,10 +28,14 @@ export class DissolveTeamCodeResolver {
     const key = `verify_dissolve_team:${team.id}`
     const code = await this.authService.getVerificationCode(key)
 
-    this.mailService.teamDeletionRequest(user.email, {
-      teamName: team.name,
-      code
-    })
+    this.mailService.teamDeletionRequest(
+      user.email,
+      {
+        teamName: team.name,
+        code
+      },
+      user.lang
+    )
 
     return true
   }

--- a/packages/server/src/resolver/team/dissolve-team.resolver.ts
+++ b/packages/server/src/resolver/team/dissolve-team.resolver.ts
@@ -46,10 +46,14 @@ export class DissolveTeamResolver {
       await this.submissionService.deleteAll(formIds)
     }
 
-    this.mailService.teamDeletionAlert(user.email, {
-      teamName: team.name,
-      userName: user.name
-    })
+    this.mailService.teamDeletionAlert(
+      user.email,
+      {
+        teamName: team.name,
+        userName: user.name
+      },
+      user.lang
+    )
 
     return true
   }

--- a/packages/server/src/resolver/team/invite-member.resolver.ts
+++ b/packages/server/src/resolver/team/invite-member.resolver.ts
@@ -40,11 +40,15 @@ export class InviteMemberResolver {
     const emails = helper.uniqueArray(input.emails.filter(email => !exists.includes(email)))
 
     for (const email of emails) {
-      this.mailService.teamInvitation(email, {
-        userName: user.name,
-        teamName: team.name,
-        link: `${APP_HOMEPAGE_URL}/workspace/${team.id}/invitation/${team.inviteCode}`
-      })
+      this.mailService.teamInvitation(
+        email,
+        {
+          userName: user.name,
+          teamName: team.name,
+          link: `${APP_HOMEPAGE_URL}/workspace/${team.id}/invitation/${team.inviteCode}`
+        },
+        user.lang
+      )
     }
 
     return true

--- a/packages/server/src/resolver/user/change-email-code.resolver.ts
+++ b/packages/server/src/resolver/user/change-email-code.resolver.ts
@@ -40,7 +40,7 @@ export class ChangeEmailCodeResolver {
     const key = `verify_email:${user.id}:${input.email}`
     const code = await this.authService.getVerificationCodeWithRateLimit(key)
 
-    this.mailService.emailVerificationRequest(input.email, code)
+    this.mailService.emailVerificationRequest(input.email, code, user.lang)
 
     return true
   }

--- a/packages/server/src/resolver/user/email-verification-code.resolver.ts
+++ b/packages/server/src/resolver/user/email-verification-code.resolver.ts
@@ -22,7 +22,7 @@ export class EmailVerificationCodeResolver {
     const key = `verify_email:${user.id}`
     const code = await this.authService.getVerificationCodeWithRateLimit(key)
 
-    this.mailService.emailVerificationRequest(user.email, code)
+    this.mailService.emailVerificationRequest(user.email, code, user.lang)
 
     return true
   }

--- a/packages/server/src/resolver/user/update-user-password.resolver.ts
+++ b/packages/server/src/resolver/user/update-user-password.resolver.ts
@@ -38,7 +38,7 @@ export class UpdateUserPasswordResolver {
 
     if (result) {
       await this.authService.invalidateSessions(user.id)
-      this.mailService.passwordChangeAlert(user.email)
+      this.mailService.passwordChangeAlert(user.email, user.lang)
     }
 
     return result

--- a/packages/server/src/resolver/user/update-user.resolver.ts
+++ b/packages/server/src/resolver/user/update-user.resolver.ts
@@ -1,7 +1,7 @@
 import { Auth, User } from '@decorator'
 import { UpdateUserInput } from '@graphql'
 import { helper } from '@heyform-inc/utils'
-import { UserModel } from '@model'
+import { UserLangEnum, UserModel } from '@model'
 import { Args, Mutation, Resolver } from '@nestjs/graphql'
 import { UserService } from '@service'
 
@@ -23,6 +23,10 @@ export class UpdateUserResolver {
 
     if (helper.isValid(input.avatar)) {
       updates.avatar = input.avatar
+    }
+
+    if (helper.isValid(input.lang) && Object.values(UserLangEnum).includes(input.lang)) {
+      updates.lang = input.lang
     }
 
     if (helper.isValid(updates)) {

--- a/packages/server/src/resolver/user/user-deletion-code.resolver.ts
+++ b/packages/server/src/resolver/user/user-deletion-code.resolver.ts
@@ -16,7 +16,7 @@ export class UserDeletionCodeResolver {
     const key = `user_deletion:${user.id}`
     const code = await this.authService.getVerificationCode(key)
 
-    await this.mailService.accountDeletionRequest(user.email, code)
+    await this.mailService.accountDeletionRequest(user.email, code, user.lang)
 
     return true
   }

--- a/packages/server/src/resolver/user/verify-user-deletion.resolver.ts
+++ b/packages/server/src/resolver/user/verify-user-deletion.resolver.ts
@@ -32,7 +32,7 @@ export class VerifyUserDeletionResolver {
       deletionScheduledAt: timestamp() + hs(ACCOUNT_DELETION_SCHEDULE_INTERVAL)
     })
 
-    await this.mailService.scheduleAccountDeletionAlert(user.email, user.name)
+    await this.mailService.scheduleAccountDeletionAlert(user.email, user.name, user.lang)
 
     return true
   }

--- a/packages/server/src/schedule/delete-user-account.schedule.ts
+++ b/packages/server/src/schedule/delete-user-account.schedule.ts
@@ -59,7 +59,7 @@ export class DeleteUserAccountSchedule extends BaseQueue {
             await this.teamService.deleteMember(teamId, userId)
           }
 
-          await this.mailService.accountDeletionAlert(user.email)
+          await this.mailService.accountDeletionAlert(user.email, user.lang)
         }
       }
     }

--- a/packages/server/src/service/mail.service.ts
+++ b/packages/server/src/service/mail.service.ts
@@ -1,7 +1,7 @@
 import { InjectQueue } from '@nestjs/bull'
 import { Injectable } from '@nestjs/common'
 import { JobOptions, Queue } from 'bull'
-import { readFileSync, readdirSync } from 'fs'
+import { Dirent, readFileSync, readdirSync } from 'fs'
 import { basename, extname, join } from 'path'
 
 import { EMAIL_TEMPLATES_DIR, SMTP_FROM } from '@environments'
@@ -54,29 +54,45 @@ interface UserSecurityAlertOptions {
 
 const HTML_EXT = '.html'
 const TEMPLATE_META_REGEX = /^---([\s\S]*?)---[\n\s\S]\n/
+const DEFAULT_LOCALE = 'en'
 
 @Injectable()
 export class MailService {
-  private readonly emailTemplates: Record<string, { subject: string; html: string }> = {}
+  private readonly emailTemplates: Record<
+    string,
+    Record<string, { subject: string; html: string }>
+  > = {}
 
   constructor(@InjectQueue('MailQueue') private readonly mailQueue: Queue) {
     this.init()
   }
 
-  async accountDeletionAlert(to: string) {
-    await this.addQueue('account_deletion_alert', to)
+  async accountDeletionAlert(to: string, locale?: string) {
+    await this.addQueue('account_deletion_alert', to, undefined, undefined, locale)
   }
 
-  async accountDeletionRequest(to: string, code: string) {
-    await this.addQueue('account_deletion_request', to, {
-      code
-    })
+  async accountDeletionRequest(to: string, code: string, locale?: string) {
+    await this.addQueue(
+      'account_deletion_request',
+      to,
+      {
+        code
+      },
+      undefined,
+      locale
+    )
   }
 
-  async emailVerificationRequest(to: string, code: string) {
-    await this.addQueue('email_verification_request', to, {
-      code
-    })
+  async emailVerificationRequest(to: string, code: string, locale?: string) {
+    await this.addQueue(
+      'email_verification_request',
+      to,
+      {
+        code
+      },
+      undefined,
+      locale
+    )
   }
 
   async formInvitation(to: string, link: string) {
@@ -89,27 +105,41 @@ export class MailService {
     await this.addQueue('join_workspace_alert', to, options)
   }
 
-  async passwordChangeAlert(to: string) {
-    await this.addQueue('password_change_alert', to)
+  async passwordChangeAlert(to: string, locale?: string) {
+    await this.addQueue('password_change_alert', to, undefined, undefined, locale)
   }
 
-  async projectDeletionAlert(to: string, options: ProjectDeletionAlertOptions) {
-    await this.addQueue('project_deletion_alert', to, options)
+  async projectDeletionAlert(to: string, options: ProjectDeletionAlertOptions, locale?: string) {
+    await this.addQueue('project_deletion_alert', to, options, undefined, locale)
   }
 
-  async projectDeletionRequest(to: string, options: ProjectDeletionRequestOptions) {
-    await this.addQueue('project_deletion_request', to, options)
+  async projectDeletionRequest(
+    to: string,
+    options: ProjectDeletionRequestOptions,
+    locale?: string
+  ) {
+    await this.addQueue('project_deletion_request', to, options, undefined, locale)
   }
 
-  async scheduleAccountDeletionAlert(to: string, fullName: string) {
-    await this.addQueue('schedule_account_deletion_alert', to, {
-      fullName,
-      email: to
-    })
+  async scheduleAccountDeletionAlert(to: string, fullName: string, locale?: string) {
+    await this.addQueue(
+      'schedule_account_deletion_alert',
+      to,
+      {
+        fullName,
+        email: to
+      },
+      undefined,
+      locale
+    )
   }
 
-  async submissionNotification(to: string, options: SubmissionNotificationOptions) {
-    await this.addQueue('submission_notification', to, options)
+  async submissionNotification(
+    to: string,
+    options: SubmissionNotificationOptions,
+    locale?: string
+  ) {
+    await this.addQueue('submission_notification', to, options, undefined, locale)
   }
 
   async teamDataExportReady(to: string, link: string) {
@@ -118,19 +148,25 @@ export class MailService {
     })
   }
 
-  async teamDeletionAlert(to: string, options: TeamDeletionAlertOptions) {
-    await this.addQueue('team_deletion_alert', to, options)
+  async teamDeletionAlert(to: string, options: TeamDeletionAlertOptions, locale?: string) {
+    await this.addQueue('team_deletion_alert', to, options, undefined, locale)
   }
 
-  async teamDeletionRequest(to: string, options: TeamDeletionRequestOptions) {
-    await this.addQueue('team_deletion_request', to, options)
+  async teamDeletionRequest(to: string, options: TeamDeletionRequestOptions, locale?: string) {
+    await this.addQueue('team_deletion_request', to, options, undefined, locale)
   }
 
-  async teamInvitation(to: string, options: TeamInvitationOptions) {
-    await this.addQueue('team_invitation', to, {
-      ...options,
-      email: to
-    })
+  async teamInvitation(to: string, options: TeamInvitationOptions, locale?: string) {
+    await this.addQueue(
+      'team_invitation',
+      to,
+      {
+        ...options,
+        email: to
+      },
+      undefined,
+      locale
+    )
   }
 
   async userSecurityAlert(to: string, options: UserSecurityAlertOptions) {
@@ -138,10 +174,22 @@ export class MailService {
   }
 
   private init() {
-    const allFiles = readdirSync(EMAIL_TEMPLATES_DIR)
-    const filePaths = allFiles
-      .filter(file => extname(file) === HTML_EXT)
-      .map(file => join(EMAIL_TEMPLATES_DIR, file))
+    this.loadTemplates(DEFAULT_LOCALE, readdirSync(EMAIL_TEMPLATES_DIR, { withFileTypes: true }))
+
+    const localeDirs = readdirSync(EMAIL_TEMPLATES_DIR, { withFileTypes: true }).filter(entry =>
+      entry.isDirectory()
+    )
+
+    localeDirs.forEach(entry => {
+      const localePath = join(EMAIL_TEMPLATES_DIR, entry.name)
+      this.loadTemplates(entry.name, readdirSync(localePath, { withFileTypes: true }), localePath)
+    })
+  }
+
+  private loadTemplates(locale: string, entries: Dirent[], basePath = EMAIL_TEMPLATES_DIR) {
+    const filePaths = entries
+      .filter(file => file.isFile() && extname(file.name) === HTML_EXT)
+      .map(file => join(basePath, file.name))
 
     for (const filePath of filePaths) {
       const name = basename(filePath, HTML_EXT)
@@ -162,7 +210,8 @@ export class MailService {
           }
         })
 
-        this.emailTemplates[name] = {
+        this.emailTemplates[locale] ||= {}
+        this.emailTemplates[locale][name] = {
           subject: metaObject.title,
           html
         }
@@ -174,9 +223,12 @@ export class MailService {
     templateName: string,
     to: string,
     replacements?: Record<string, any>,
-    options?: JobOptions
+    options?: JobOptions,
+    locale = DEFAULT_LOCALE
   ) {
-    const result = this.emailTemplates[templateName]
+    const result =
+      this.emailTemplates[locale]?.[templateName] ||
+      this.emailTemplates[DEFAULT_LOCALE]?.[templateName]
 
     if (helper.isEmpty(result)) {
       return

--- a/packages/server/src/utils/decorators/client.ts
+++ b/packages/server/src/utils/decorators/client.ts
@@ -23,7 +23,7 @@ export const GqlClient = createParamDecorator((_: any, context: ExecutionContext
     deviceId: req.get('x-device-id'),
     userAgent: parseUserAgent(req.get('user-agent')),
     ip: cip,
-    lang: lang(req, 'user-lang', ['en', 'zh-cn'])
+    lang: lang(req, 'user-lang', ['en', 'pt-br', 'zh-cn'])
   }
 })
 
@@ -35,6 +35,6 @@ export const HttpClient = createParamDecorator((_: any, ctx: ExecutionContext): 
     deviceId: req.get('x-device-id'),
     userAgent: parseUserAgent(req.get('user-agent')),
     ip: cip,
-    lang: lang(req, 'user-lang', ['en', 'zh-cn'])
+    lang: lang(req, 'user-lang', ['en', 'pt-br', 'zh-cn'])
   }
 })

--- a/packages/server/src/utils/social-login/utils.ts
+++ b/packages/server/src/utils/social-login/utils.ts
@@ -12,7 +12,7 @@ export function generateUrl(prefixUri: string, query: Record<string, any>): stri
   return `${prefixUri}?${queryString}`
 }
 
-export const defaultLocales = ['en', 'zh-cn']
+export const defaultLocales = ['en', 'pt-br', 'zh-cn']
 
 export function formatLocale(lang?: string, whiteList?: string[]): string {
   const customWhiteList = whiteList || defaultLocales

--- a/packages/webapp/src/layouts/Workspace/WorkspaceAccount.tsx
+++ b/packages/webapp/src/layouts/Workspace/WorkspaceAccount.tsx
@@ -4,6 +4,7 @@ import { useLocalStorageState } from 'ahooks'
 import { useCallback, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { UserService } from '@/services'
 import { clearAuthState, cn, useRouter } from '@/utils'
 
 import { Avatar, Button } from '@/components'
@@ -28,7 +29,7 @@ export default function WorkspaceAccount({
   const { t, i18n } = useTranslation()
 
   const router = useRouter()
-  const { user } = useUserStore()
+  const { user, updateUser } = useUserStore()
   const { openModal } = useAppStore()
 
   const [appearance, setAppearance] = useLocalStorageState(APPEARANCE_STORAGE_KEY, {
@@ -41,6 +42,15 @@ export default function WorkspaceAccount({
     router.redirect('/logout', {
       extend: false
     })
+  }
+
+  async function handleLanguageChange(lang: string) {
+    await i18n.changeLanguage(lang)
+
+    if (user.lang !== lang) {
+      updateUser({ lang })
+      UserService.update({ lang })
+    }
   }
 
   const handleChange = useCallback(
@@ -140,7 +150,7 @@ export default function WorkspaceAccount({
                     <DropdownMenu.Item
                       key={l.value}
                       className="text-primary data-[highlighted]:bg-accent-light grid cursor-pointer grid-cols-[theme(spacing.5),1fr] items-center gap-x-2.5 rounded-lg px-3 py-2.5 text-base/6 outline-none focus-visible:outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 sm:grid-cols-[theme(spacing.4),1fr] sm:px-2 sm:py-1.5 sm:text-sm/6"
-                      onClick={() => i18n.changeLanguage(l.value)}
+                      onClick={() => handleLanguageChange(l.value)}
                     >
                       {i18n.language === l.value ? (
                         <IconCheck className="text-secondary h-[1.125rem] w-[1.125rem]" />

--- a/packages/webapp/src/services/user.ts
+++ b/packages/webapp/src/services/user.ts
@@ -22,7 +22,12 @@ export class UserService {
     })
   }
 
-  static update(input: { name?: string; avatar?: string; restoreGravatar?: boolean }) {
+  static update(input: {
+    name?: string
+    avatar?: string
+    restoreGravatar?: boolean
+    lang?: string
+  }) {
     return apollo.mutate({
       mutation: UPDATE_USER_DETAIL_GQL,
       variables: {

--- a/packages/webapp/src/types/user.ts
+++ b/packages/webapp/src/types/user.ts
@@ -5,6 +5,7 @@ export interface UserType {
   phoneNumber: string
   avatar: string
   note: string
+  lang?: string
   lastSeenAt?: number
   isSocialAccount?: boolean
   isEmailVerified?: boolean

--- a/packages/webapp/src/utils/apollo.ts
+++ b/packages/webapp/src/utils/apollo.ts
@@ -16,7 +16,7 @@ import ApolloLinkTimeout from 'apollo-link-timeout'
 
 import { helper } from '@heyform-inc/utils'
 
-import { GRAPHQL_API_URL, IS_PROD } from '@/consts'
+import { GRAPHQL_API_URL, IS_PROD, LOCALE_COOKIE_NAME } from '@/consts'
 
 import { clearAuthState, getDeviceId } from './auth'
 
@@ -50,13 +50,21 @@ const retryLink: any = new RetryLink({
 
 const timeoutLink = new ApolloLinkTimeout(30_000)
 
+function getLocale() {
+  return document.cookie
+    .split('; ')
+    .find(row => row.startsWith(`${LOCALE_COOKIE_NAME}=`))
+    ?.split('=')[1]
+}
+
 const headerLink = setContext((_, { headers }) => {
   const deviceId = getDeviceId()
   return {
     headers: {
       ...headers,
       'X-Device-Id': deviceId,
-      'x-anonymous-id': deviceId
+      'x-anonymous-id': deviceId,
+      'user-lang': getLocale() || navigator.language
     }
   }
 })


### PR DESCRIPTION
Closes #280

## Summary

- Load transactional email templates per locale with `en` fallback
- Add Portuguese (Brazil) HTML templates under `email-templates/pt-br/`
- Extend `UserLangEnum` and `user-lang` handling with `pt-br`
- Persist language from the webapp via `updateUser`
- Pass `user.lang` when queueing transactional emails

Depends on #279 for the webapp language selector UX, but can be reviewed independently.

## Test plan

- [x] `pnpm build:server`
- [x] `pnpm --filter ./packages/server type-check`
- [ ] Set account language to pt-BR and trigger email verification
- [ ] Confirm email subject/body are Portuguese
- [ ] Confirm fallback to English for unknown locale


Made with [Cursor](https://cursor.com)