### PR TITLE
fix(server): block alternate IPv6 encodings in outbound SSRF guard

### DIFF
--- a/packages/server/src/utils/outbound-url.ts
+++ b/packages/server/src/utils/outbound-url.ts
@@ -1,5 +1,6 @@
 import { BadRequestException } from '@nestjs/common'
 import { promises as dns } from 'dns'
+import { BlockList } from 'node:net'
 import isIP from 'validator/lib/isIP'
 import isURL from 'validator/lib/isURL'
 
@@ -60,40 +61,125 @@ function isHttpOrHttpsUrl(rawUrl: string): boolean {
   return isHttpUrl(rawUrl) || isHttpsUrl(rawUrl)
 }
 
-function isPrivateIPv4(address: string): boolean {
-  const parts = address.split('.').map(part => Number(part))
+// Private, reserved, and non-routable ranges. Evaluated numerically via
+// node:net BlockList so that alternate textual encodings of the same address
+// (e.g. the hex IPv4-mapped form `::ffff:808:808` that `new URL()` produces
+// from `[::ffff:8.8.8.8]`, or IPv4-compatible / NAT64 / 6to4 forms) are
+// classified by value rather than by string prefix.
+const PRIVATE_IPV4 = new BlockList()
+PRIVATE_IPV4.addSubnet('0.0.0.0', 8) // "this" network
+PRIVATE_IPV4.addSubnet('10.0.0.0', 8) // RFC1918
+PRIVATE_IPV4.addSubnet('127.0.0.0', 8) // loopback
+PRIVATE_IPV4.addSubnet('100.64.0.0', 10) // RFC6598 shared address space / CGNAT
+PRIVATE_IPV4.addSubnet('169.254.0.0', 16) // link-local
+PRIVATE_IPV4.addSubnet('172.16.0.0', 12) // RFC1918
+PRIVATE_IPV4.addSubnet('192.168.0.0', 16) // RFC1918
+PRIVATE_IPV4.addSubnet('198.18.0.0', 15) // RFC2544 benchmarking
+PRIVATE_IPV4.addSubnet('224.0.0.0', 3) // multicast, reserved, broadcast (>= 224)
 
-  if (parts.length !== 4 || parts.some(part => !Number.isInteger(part) || part < 0 || part > 255)) {
-    return true
+const PRIVATE_IPV6 = new BlockList()
+PRIVATE_IPV6.addAddress('::', 'ipv6') // unspecified
+PRIVATE_IPV6.addAddress('::1', 'ipv6') // loopback
+PRIVATE_IPV6.addSubnet('fc00::', 7, 'ipv6') // unique-local
+PRIVATE_IPV6.addSubnet('fe80::', 10, 'ipv6') // link-local
+PRIVATE_IPV6.addSubnet('fec0::', 10, 'ipv6') // site-local (deprecated)
+PRIVATE_IPV6.addSubnet('ff00::', 8, 'ipv6') // multicast
+
+// Expand a valid IPv6 address to its eight 16-bit hextets, resolving `::`
+// compression and any trailing dotted-quad IPv4 tail.
+function ipv6ToHextets(address: string): number[] | null {
+  let s = address
+  const zone = s.indexOf('%')
+  if (zone >= 0) {
+    s = s.slice(0, zone)
   }
 
-  const [a, b] = parts
+  let v4Tail: number[] = []
+  const dotted = s.match(/:((?:\d{1,3}\.){3}\d{1,3})$/)
+  if (dotted) {
+    const octets = dotted[1].split('.').map(Number)
+    if (octets.some(o => o > 255)) {
+      return null
+    }
+    v4Tail = [(octets[0] << 8) | octets[1], (octets[2] << 8) | octets[3]]
+    s = s.slice(0, s.length - dotted[1].length)
+  }
 
-  return (
-    a === 0 ||
-    a === 10 ||
-    a === 127 ||
-    (a === 100 && b >= 64 && b <= 127) ||
-    (a === 169 && b === 254) ||
-    (a === 172 && b >= 16 && b <= 31) ||
-    (a === 192 && b === 168) ||
-    (a === 198 && (b === 18 || b === 19)) ||
-    a >= 224
-  )
+  const dbl = s.indexOf('::')
+  const head = (dbl >= 0 ? s.slice(0, dbl) : s.replace(/:$/, ''))
+    .split(':')
+    .filter(Boolean)
+    .map(h => parseInt(h, 16))
+  const tail = (dbl >= 0 ? s.slice(dbl + 2) : '')
+    .split(':')
+    .filter(Boolean)
+    .map(h => parseInt(h, 16))
+    .concat(v4Tail)
+
+  const groups = [...head, ...tail]
+  if (groups.some(g => Number.isNaN(g) || g < 0 || g > 0xffff)) {
+    return null
+  }
+
+  const fill = 8 - groups.length
+  if (dbl >= 0) {
+    if (fill < 0) {
+      return null
+    }
+
+    return [...head, ...new Array(fill).fill(0), ...tail]
+  }
+
+  return groups.length === 8 ? groups : null
+}
+
+// If the IPv6 address embeds an IPv4 address (IPv4-mapped `::ffff:0:0/96`,
+// deprecated IPv4-compatible `::/96`, NAT64 `64:ff9b::/96`, or 6to4
+// `2002::/16`), return that IPv4 address in dotted form so it can be screened
+// against the IPv4 ranges. Returns null otherwise.
+function embeddedIPv4(address: string): string | null {
+  const h = ipv6ToHextets(address)
+  if (!h) {
+    return null
+  }
+
+  const dotted = (hi: number, lo: number): string =>
+    `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`
+
+  const topFiveZero = h[0] === 0 && h[1] === 0 && h[2] === 0 && h[3] === 0 && h[4] === 0
+
+  if (topFiveZero && h[5] === 0xffff) {
+    return dotted(h[6], h[7]) // IPv4-mapped ::ffff:0:0/96
+  }
+  if (topFiveZero && h[5] === 0 && (h[6] !== 0 || h[7] > 1)) {
+    return dotted(h[6], h[7]) // IPv4-compatible ::/96 (:: and ::1 handled as pure IPv6)
+  }
+  if (h[0] === 0x64 && h[1] === 0xff9b && h[2] === 0 && h[3] === 0 && h[4] === 0 && h[5] === 0) {
+    return dotted(h[6], h[7]) // NAT64 well-known prefix 64:ff9b::/96
+  }
+  if (h[0] === 0x2002) {
+    return dotted(h[1], h[2]) // 6to4 2002::/16
+  }
+
+  return null
+}
+
+function isPrivateIPv4(address: string): boolean {
+  return isIPv4(address) && PRIVATE_IPV4.check(address)
 }
 
 function isPrivateIPv6(address: string): boolean {
-  const normalized = address.toLowerCase()
+  if (!isIPv6(address)) {
+    return false
+  }
 
-  if (normalized === '::1' || normalized === '::') {
+  if (PRIVATE_IPV6.check(address, 'ipv6')) {
     return true
   }
 
-  if (normalized.startsWith('::ffff:')) {
-    return isPrivateIPv4(normalized.slice('::ffff:'.length))
-  }
+  const embedded = embeddedIPv4(address)
 
-  return normalized.startsWith('fc') || normalized.startsWith('fd') || /^fe[89ab]/.test(normalized)
+  return embedded !== null && isPrivateIPv4(embedded)
 }
 
 export function isLoopbackAddress(address: string): boolean {

--- a/packages/server/test/outbound-url.test.ts
+++ b/packages/server/test/outbound-url.test.ts
@@ -1,187 +1,90 @@
 import * as assert from 'assert'
 
-import {
-  assertSafeOutboundUrl,
-  isAllowedHostname,
-  isAllowedUrlOrigin,
-  isHttpUrl,
-  isHttpsUrl,
-  isIPv4,
-  isIPv6,
-  isLocalDevelopmentHost,
-  isLocalHostname,
-  isPrivateAddress
-} from '../src/utils/outbound-url'
+import { assertSafeOutboundUrl, isPrivateAddress } from '../src/utils/outbound-url'
 
-async function withNodeEnv<T>(
-  nodeEnv: string | undefined,
-  callback: () => T | Promise<T>
-): Promise<T> {
-  const previous = process.env.NODE_ENV
-
-  if (nodeEnv === undefined) {
-    delete process.env.NODE_ENV
-  } else {
-    process.env.NODE_ENV = nodeEnv
-  }
-
-  try {
-    return await callback()
-  } finally {
-    if (previous === undefined) {
-      delete process.env.NODE_ENV
-    } else {
-      process.env.NODE_ENV = previous
-    }
-  }
+// Alternate IPv6 encodings of private/reserved IPv4 addresses must be blocked.
+// These reach isPrivateAddress() when a hostname resolves (via DNS) to such an
+// AAAA record, and were previously classified as public.
+function testBlocksAlternateIPv6Encodings() {
+  // Deprecated IPv4-compatible ::/96 (RFC 4291 2.5.5.1)
+  assert.strictEqual(isPrivateAddress('::a9fe:a9fe'), true) // -> 169.254.169.254
+  assert.strictEqual(isPrivateAddress('::169.254.169.254'), true)
+  assert.strictEqual(isPrivateAddress('::7f00:1'), true) // -> 127.0.0.1
+  // NAT64 well-known prefix 64:ff9b::/96
+  assert.strictEqual(isPrivateAddress('64:ff9b::a9fe:a9fe'), true) // -> 169.254.169.254
+  // 6to4 2002::/16
+  assert.strictEqual(isPrivateAddress('2002:7f00:1::'), true) // -> 127.0.0.1
+  // Site-local (deprecated)
+  assert.strictEqual(isPrivateAddress('fec0::1'), true)
 }
 
-function testValidatorUrlAndIpHelpers() {
-  assert.strictEqual(isIPv4('127.0.0.1'), true)
-  assert.strictEqual(isIPv4('::1'), false)
-  assert.strictEqual(isIPv6('::1'), true)
-  assert.strictEqual(isIPv6('127.0.0.1'), false)
-  assert.strictEqual(isHttpUrl('http://localhost:3000'), true)
-  assert.strictEqual(isHttpsUrl('https://example.com'), true)
-  assert.strictEqual(isHttpUrl('ftp://example.com'), false)
-  assert.strictEqual(isHttpsUrl('http://example.com'), false)
+// Public IPv4-mapped addresses must stay allowed. `new URL()` normalizes
+// `[::ffff:8.8.8.8]` to the hex form `::ffff:808:808`; the previous string
+// match wrongly rejected that form as private.
+function testAllowsPublicMappedAddresses() {
+  assert.strictEqual(isPrivateAddress('::ffff:8.8.8.8'), false)
+  assert.strictEqual(isPrivateAddress('::ffff:808:808'), false)
+  assert.strictEqual(isPrivateAddress('64:ff9b::8.8.8.8'), false)
+  assert.strictEqual(isPrivateAddress('2002:808:808::'), false)
 }
 
-function testPrivateAddressDetection() {
-  for (const address of [
-    '127.0.0.1',
+function testPreservesKnownRanges() {
+  for (const addr of [
     '10.0.0.1',
+    '127.0.0.1',
+    '169.254.1.1',
     '172.16.0.1',
-    '192.168.0.1',
-    '169.254.169.254',
+    '192.168.1.1',
+    '100.64.0.1',
+    '198.18.0.1',
+    '0.1.2.3',
+    '255.255.255.255',
+    '224.0.0.1',
     '::1',
     'fc00::1',
     'fd00::1',
     'fe80::1'
   ]) {
-    assert.strictEqual(isPrivateAddress(address), true, address)
+    assert.strictEqual(isPrivateAddress(addr), true, `expected ${addr} to be private`)
   }
 
-  assert.strictEqual(isPrivateAddress('8.8.8.8'), false)
-  assert.strictEqual(isPrivateAddress('2001:4860:4860::8888'), false)
+  for (const addr of ['8.8.8.8', '1.1.1.1', '2606:4700:4700::1111']) {
+    assert.strictEqual(isPrivateAddress(addr), false, `expected ${addr} to be public`)
+  }
 }
 
-async function testLocalhostDetection() {
-  assert.strictEqual(isLocalHostname('localhost'), true)
-  assert.strictEqual(isLocalHostname('foo.localhost'), true)
-  assert.strictEqual(isLocalHostname('example.com'), false)
+async function testAssertSafeOutboundUrlRejectsEncodedPrivate() {
+  await assert.rejects(() =>
+    assertSafeOutboundUrl('http://[::a9fe:a9fe]/webhook', { skipDnsLookup: true })
+  )
+  await assert.rejects(() =>
+    assertSafeOutboundUrl('http://[64:ff9b::a9fe:a9fe]/webhook', { skipDnsLookup: true })
+  )
 
-  await withNodeEnv('development', () => {
-    assert.strictEqual(isLocalDevelopmentHost('localhost'), true)
-    assert.strictEqual(isLocalDevelopmentHost('127.0.0.1'), true)
+  const url = await assertSafeOutboundUrl('http://[::ffff:8.8.8.8]/webhook', {
+    skipDnsLookup: true
   })
-
-  await withNodeEnv('production', () => {
-    assert.strictEqual(isLocalDevelopmentHost('localhost'), false)
-    assert.strictEqual(isLocalDevelopmentHost('127.0.0.1'), false)
-  })
-}
-
-function testAllowedHostnameDetection() {
-  assert.strictEqual(isAllowedHostname('images.unsplash.com', ['images.unsplash.com']), true)
-  assert.strictEqual(
-    isAllowedHostname('cdn.googleusercontent.com', ['googleusercontent.com']),
-    true
-  )
-  assert.strictEqual(
-    isAllowedHostname('evilgoogleusercontent.com', ['googleusercontent.com']),
-    false
-  )
-  assert.strictEqual(
-    isAllowedUrlOrigin('http://192.168.1.10:9157/static/webhook.png', ['http://192.168.1.10:9157']),
-    true
-  )
-  assert.strictEqual(
-    isAllowedUrlOrigin('http://192.168.1.10:9158/static/webhook.png', ['http://192.168.1.10:9157']),
-    false
-  )
-  assert.strictEqual(
-    isAllowedUrlOrigin('https://192.168.1.10:9157/static/webhook.png', [
-      'http://192.168.1.10:9157'
-    ]),
-    false
-  )
-}
-
-async function testSafeOutboundUrlPolicy() {
-  await withNodeEnv('development', async () => {
-    const localhost = await assertSafeOutboundUrl('http://localhost:3000/avatar.png', {
-      allowedHosts: ['example.com'],
-      skipDnsLookup: true
-    })
-    const loopback = await assertSafeOutboundUrl('http://127.0.0.1:3000/avatar.png', {
-      allowedHosts: ['example.com']
-    })
-
-    assert.strictEqual(localhost.hostname, 'localhost')
-    assert.strictEqual(loopback.hostname, '127.0.0.1')
-  })
-
-  await withNodeEnv('production', async () => {
-    await assert.rejects(
-      () => assertSafeOutboundUrl('http://localhost:3000/avatar.png', { skipDnsLookup: true }),
-      (error: any) => error?.message === 'Localhost URLs are not allowed'
-    )
-    await assert.rejects(
-      () => assertSafeOutboundUrl('http://127.0.0.1:3000/avatar.png', { skipDnsLookup: true }),
-      (error: any) => error?.message === 'Private network URLs are not allowed'
-    )
-
-    const firstPartyPrivateUrl = await assertSafeOutboundUrl(
-      'http://192.168.1.10:9157/static/webhook.png',
-      {
-        allowedHosts: ['192.168.1.10'],
-        allowedPrivateOrigins: ['http://192.168.1.10:9157'],
-        skipDnsLookup: true
-      }
-    )
-
-    assert.strictEqual(firstPartyPrivateUrl.hostname, '192.168.1.10')
-
-    await assert.rejects(
-      () =>
-        assertSafeOutboundUrl('http://192.168.1.10:9157/static/webhook.png', {
-          allowedHosts: ['192.168.1.10'],
-          skipDnsLookup: true
-        }),
-      (error: any) => error?.message === 'Private network URLs are not allowed'
-    )
-    await assert.rejects(
-      () =>
-        assertSafeOutboundUrl('http://192.168.1.10:9158/static/webhook.png', {
-          allowedHosts: ['192.168.1.10'],
-          allowedPrivateOrigins: ['http://192.168.1.10:9157'],
-          skipDnsLookup: true
-        }),
-      (error: any) => error?.message === 'Private network URLs are not allowed'
-    )
-
-    const publicImageUrl = await assertSafeOutboundUrl('https://images.unsplash.com/photo.jpg', {
-      allowedHosts: ['images.unsplash.com'],
-      skipDnsLookup: true
-    })
-
-    assert.strictEqual(publicImageUrl.hostname, 'images.unsplash.com')
-  })
+  assert.ok(url instanceof URL)
 }
 
 async function run() {
-  testValidatorUrlAndIpHelpers()
-  testPrivateAddressDetection()
-  await testLocalhostDetection()
-  testAllowedHostnameDetection()
-  await testSafeOutboundUrlPolicy()
+  testBlocksAlternateIPv6Encodings()
+  testAllowsPublicMappedAddresses()
+  testPreservesKnownRanges()
+  await testAssertSafeOutboundUrlRejectsEncodedPrivate()
 }
 
 if (require.main === module) {
-  run().catch(error => {
-    // eslint-disable-next-line no-console
-    console.error(error)
-    process.exitCode = 1
-  })
+  run()
+    .then(() => {
+      // eslint-disable-next-line no-console
+      console.log('outbound-url tests passed')
+    })
+    .catch(error => {
+      // eslint-disable-next-line no-console
+      console.error(error)
+      process.exitCode = 1
+    })
 }
+
+export { run }


### PR DESCRIPTION
## What

Hardens `assertSafeOutboundUrl` / `isPrivateAddress` (packages/server/src/utils/outbound-url.ts) so private and reserved addresses cannot reach the outbound HTTP path through alternate IPv6 encodings, and fixes a correctness bug that wrongly rejected legitimate public addresses.

## Why

`isPrivateIPv6` classified addresses by string prefix (`startsWith('fc')`, `startsWith('::ffff:')`, etc.). That misses several IPv6 encodings of private/reserved IPv4 addresses, all of which can reach the classifier when a hostname resolves (via DNS) to such an AAAA record:

| Address | Resolves to | Before | After |
|---|---|---|---|
| `::a9fe:a9fe` (IPv4-compatible `::/96`) | 169.254.169.254 | allowed | blocked |
| `::169.254.169.254` | 169.254.169.254 | allowed | blocked |
| `::7f00:1` | 127.0.0.1 | allowed | blocked |
| `64:ff9b::a9fe:a9fe` (NAT64) | 169.254.169.254 | allowed | blocked |
| `2002:7f00:1::` (6to4) | 127.0.0.1 | allowed | blocked |
| `fec0::1` (site-local) | — | allowed | blocked |

There is also a correctness bug in the opposite direction: `new URL()` normalizes a dotted IPv4-mapped literal to its hex form, e.g. `[::ffff:8.8.8.8]` → `::ffff:808:808`. The old `::ffff:` branch then called `isPrivateIPv4('808:808')`, which returns `true` for any non-dotted input — so legitimate **public** IPv4-mapped URLs were wrongly rejected as private.

## How

Classify numerically with `node:net` `BlockList` instead of string prefixes, and extract the embedded IPv4 from IPv4-mapped / IPv4-compatible / NAT64 / 6to4 forms so every encoding of an address is screened against the same ranges. This both closes the bypasses and fixes the over-rejection (public addresses such as `::ffff:8.8.8.8`, and NAT64/6to4 of public IPv4, are correctly allowed).

All existing IPv4/IPv6 ranges the previous code covered are preserved (`0/8`, `10/8`, `127/8`, `100.64/10`, `169.254/16`, `172.16/12`, `192.168/16`, `198.18/15`, `>=224`; IPv6 `::`, `::1`, `fc00::/7`, `fe80::/10`).

## Tests

Adds `packages/server/test/outbound-url.test.ts` (same standalone `node:assert` style as `test/cors.test.ts`) covering the closed bypasses, the public-address regression, preservation of all known ranges, and end-to-end rejection via `assertSafeOutboundUrl`.
