### PR TITLE
Render group page titles as plain text

### DIFF
--- a/packages/webapp/src/pages/form/Builder/Compose/Blocks/Block.tsx
+++ b/packages/webapp/src/pages/form/Builder/Compose/Blocks/Block.tsx
@@ -208,7 +208,9 @@ export const Block: FC<BlockProps> = ({
       {parentField && (
         <div className="heyform-block-group rounded-t-lg">
           <div className="heyform-block-group-container">
-            <div className="heyform-block-title">{parentField.title}</div>
+            <div className="heyform-block-title">
+              {htmlUtils.plain(parentField.title as string)}
+            </div>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary

- render formatted group titles as plain text in the builder's nested page header
- reuse the same title conversion already used by the live renderer and other builder surfaces
- preserve readable bold, italic, link and entity text without exposing markup

Closes #300

## Verification

- formatted-title render probe
- focused Prettier and Oxlint checks
- full repository lint (0 errors)
- webapp production build
- typecheck baseline unchanged at 465 pre-existing errors, with none in the changed file
- `git diff --check`
