### PR TITLE
Fix LRU cache evicting the most-recently-used entry

### DIFF
--- a/packages/form-renderer/src/utils/lru.ts
+++ b/packages/form-renderer/src/utils/lru.ts
@@ -92,7 +92,7 @@ export class LRU {
 
     // Pop first item
     if (this.cache.keys.length >= this.capacity) {
-      const k = this.cache.keys.pop()!
+      const k = this.cache.keys.shift()!
       this.destroy(k)
     }
 

--- a/packages/webapp/src/pages/form/Render/utils/lru.ts
+++ b/packages/webapp/src/pages/form/Render/utils/lru.ts
@@ -92,7 +92,7 @@ export class LRU {
 
     // Pop first item
     if (this.cache.keys.length >= this.capacity) {
-      const k = this.cache.keys.pop()!
+      const k = this.cache.keys.shift()!
       this.destroy(k)
     }
 


### PR DESCRIPTION
## Problem

`LRUCache.put` (`packages/form-renderer/src/utils/lru.ts`) tracks recency in `this.cache.keys`, pushing the newest key to the **end**:

```ts
this.cache.keys.push(key)   // newest at the back → keys[0] is oldest, keys[length-1] is newest
```

The eviction step is commented *"Pop first item"* (i.e. drop the **oldest**), but uses `pop()`, which removes the **last** — the most-recently-used — key:

```ts
// Pop first item
if (this.cache.keys.length >= this.capacity) {
  const k = this.cache.keys.pop()!   // removes newest, not oldest
  this.destroy(k)
}
```

## Impact

The cache stores each form's in-progress / auto-saved answers keyed by `formId` (default capacity 10; `store.ts` calls `getLRU().put(formId, cache)` on every save and `.get(formId)` to restore). Two concrete failures:

1. **At capacity, adding a new form evicts the most-recently-used form's saved answers** instead of the stalest — a user returning to the form they were just working on finds their saved data gone while an untouched old form is kept.
2. **Re-`put`ting an already-cached key while at capacity destroys an unrelated newer entry.** Since the store calls `put` on every save of an existing form, a full cache silently drops another form's answers on each save.

## Fix

Remove the oldest key with `shift()`, matching the "Pop first item" comment and the push-to-end convention:

```ts
const k = this.cache.keys.shift()!
```

## Reproduction

Capacity 3, insert `a, b, c`, then `put('d')`:

| | keys after | oldest `a` kept? | newest `c` kept? |
|---|---|---|---|
| before (`pop`) | `[a, b, d]` | yes ❌ | no ❌ |
| after (`shift`) | `[b, c, d]` | no ✅ | yes ✅ |

And re-`put('a')` while full: before drops `b`; after keeps `b` and moves `a` to newest.

The identical bug exists in the webapp copy (`packages/webapp/src/pages/form/Render/utils/lru.ts`) and is fixed in the same commit.
