### PR TITLE
fix: expose removeBranding to public forms

### DIFF
--- a/packages/server/src/common/graphql/form.graphql.ts
+++ b/packages/server/src/common/graphql/form.graphql.ts
@@ -991,6 +991,9 @@ export class FormSettingType {
 
   @Field({ nullable: true })
   enableEmailNotification?: boolean
+
+  @Field({ nullable: true })
+  removeBranding?: boolean
 }
 
 @ObjectType()

--- a/packages/server/test/e2e/helpers/gql.ts
+++ b/packages/server/test/e2e/helpers/gql.ts
@@ -424,6 +424,7 @@ export const PUBLIC_FORM_GQL = /* GraphQL */ `
       name
       settings {
         active
+        removeBranding
       }
       fields {
         id

--- a/packages/server/test/e2e/team-flow.e2e.test.ts
+++ b/packages/server/test/e2e/team-flow.e2e.test.ts
@@ -24,7 +24,8 @@ import {
   TEAMS_GQL,
   TEAM_MEMBERS_GQL,
   UPDATE_FORM_SCHEMAS_GQL,
-  UPDATE_SUBMISSIONS_CATEGORY_GQL
+  UPDATE_SUBMISSIONS_CATEGORY_GQL,
+  UPDATE_TEAM_GQL
 } from './helpers/gql'
 import { randomString, strongPassword, uniqueEmail, uniqueName } from './helpers/random'
 import { defineSuite } from './helpers/runner'
@@ -250,6 +251,20 @@ export function build(baseUrl: string) {
       input: { formId, drafts, version: updated.version }
     })
     assert.strictEqual(published, true)
+  })
+
+  test('anonymous respondent receives the workspace branding setting', async () => {
+    const { admin, formId, teamId } = need(state, ['admin', 'formId', 'teamId'])
+
+    await admin.client.gqlOk<boolean>('updateTeam', UPDATE_TEAM_GQL, {
+      input: { teamId, removeBranding: true }
+    })
+
+    const respondent = new E2EClient({ baseUrl })
+    const publicForm = await respondent.gqlOk<any>('publicForm', PUBLIC_FORM_GQL, {
+      input: { formId }
+    })
+    assert.strictEqual(publicForm.settings.removeBranding, true)
   })
 
   test('anonymous respondent submits to the form', async () => {

--- a/packages/webapp/src/consts/gql.ts
+++ b/packages/webapp/src/consts/gql.ts
@@ -1423,6 +1423,7 @@ export const PUBLIC_FORM_GQL = gql`
         enableClosedMessage
         closedFormTitle
         closedFormDescription
+        removeBranding
       }
       drafts {
         id


### PR DESCRIPTION
## What changed

- expose `removeBranding` through the public form GraphQL settings
- request the flag in `PUBLIC_FORM_GQL` so the renderer can honor it
- cover the workspace-to-public-form path in the server E2E flow

The server already copied the workspace flag into public form settings. The GraphQL type and browser query omitted it, so the form renderer always received `undefined` and kept the HeyForm badge visible.

Closes #266

## Verification

- syntax checked all four changed TypeScript files
- verified the schema, browser query, and E2E query each include the field exactly once
- `git diff --check`

The full E2E suite needs the installed workspace plus MongoDB and Redis, so the repository CI will run that environment-backed check.