### PR TITLE
fix: respect email verification setting

### DIFF
--- a/packages/server/src/controller/dashboard.controller.ts
+++ b/packages/server/src/controller/dashboard.controller.ts
@@ -9,7 +9,8 @@ import {
   ENABLE_GOOGLE_FONTS,
   GOOGLE_RECAPTCHA_KEY,
   STRIPE_PUBLISHABLE_KEY,
-  VERIFY_EMAIL_RESEND_COOLDOWN
+  VERIFY_EMAIL_RESEND_COOLDOWN,
+  VERIFY_USER_EMAIL
 } from '@environments'
 import { hs } from '@heyform-inc/utils'
 import { TRUSTED_UPLOAD_ORIGINS } from '@utils'
@@ -26,6 +27,7 @@ export class DashboardController {
       stripePublishableKey: STRIPE_PUBLISHABLE_KEY,
       googleRecaptchaKey: GOOGLE_RECAPTCHA_KEY,
       uploadOrigins: TRUSTED_UPLOAD_ORIGINS,
+      verifyUserEmail: VERIFY_USER_EMAIL,
       verifyEmailResendCooldownSeconds: Math.ceil(hs(VERIFY_EMAIL_RESEND_COOLDOWN) / 1000)
     }
   }

--- a/packages/webapp/src/layouts/Workspace/index.tsx
+++ b/packages/webapp/src/layouts/Workspace/index.tsx
@@ -11,7 +11,7 @@ import { helper, timestamp } from '@heyform-inc/utils'
 
 import Logo from '@/assets/logo.svg?react'
 import { Button, useAlert } from '@/components'
-import { REDIRECT_COOKIE_NAME } from '@/consts'
+import { REDIRECT_COOKIE_NAME, VERIFY_USER_EMAIL } from '@/consts'
 import { useAppStore, useUserStore, useWorkspaceStore } from '@/store'
 
 import { FormShell } from '../Form/FormShell'
@@ -41,7 +41,11 @@ export const LoginGuard: FC<LayoutProps> = ({ options, children }) => {
       const user = await UserService.userDetail()
       setUser(user)
 
-      if (!user.isEmailVerified && window.location.pathname !== '/verify-email') {
+      if (
+        VERIFY_USER_EMAIL &&
+        !user.isEmailVerified &&
+        window.location.pathname !== '/verify-email'
+      ) {
         return router.replace('/verify-email')
       }
     } finally {

--- a/packages/webapp/src/pages/auth/SignUp.tsx
+++ b/packages/webapp/src/pages/auth/SignUp.tsx
@@ -7,7 +7,7 @@ import { clearCookie, clearInvitationCookie, getInvitationCookie, useRouter } fr
 import { helper } from '@heyform-inc/utils'
 
 import { Form, Input, PasswordStrength } from '@/components'
-import { REDIRECT_COOKIE_NAME } from '@/consts'
+import { REDIRECT_COOKIE_NAME, VERIFY_USER_EMAIL } from '@/consts'
 import { useUserStore } from '@/store'
 
 import SocialLogin from './SocialLogin'
@@ -33,9 +33,13 @@ const SignUp = () => {
 
     clearInvitationCookie()
     clearCookie(REDIRECT_COOKIE_NAME)
-    setTemporaryEmail(values.email)
-    setVerifyEmailSentAt(Date.now())
-    router.replace('/verify-email')
+    if (VERIFY_USER_EMAIL) {
+      setTemporaryEmail(values.email)
+      setVerifyEmailSentAt(Date.now())
+      router.replace('/verify-email')
+    } else {
+      router.replace('/workspace')
+    }
   }
 
   return (


### PR DESCRIPTION
Currently if email verification is disabled via environemnt variables, the frontend will still require you to verify your email (not honoring the variable), which results in heyform being unusable without smtp server.