### PR TITLE
feat: add pseudonym response IDs

### DIFF
--- a/packages/form-renderer/src/Renderer.tsx
+++ b/packages/form-renderer/src/Renderer.tsx
@@ -16,7 +16,7 @@ import { helper, nanoid } from '@heyform-inc/utils'
 
 import { ClosedMessage } from './blocks/ClosedMessage'
 import { SuspendedMessage } from './blocks/SuspendedMessage'
-import type { IState, IStripe } from './store'
+import type { IState, IStripe, ISubmitResult } from './store'
 import { StoreContext, StoreReducer, getStorage } from './store'
 import { getTheme } from './theme'
 import type { IFormModel } from './typings'
@@ -37,7 +37,11 @@ export interface FormRendererProps {
   enableQuestionList?: boolean
   enableNavigationArrows?: boolean
   ssr?: boolean
-  onSubmit?: (values: Record<string, any>, isPartial?: boolean, stripe?: IStripe) => Promise<void>
+  onSubmit?: (
+    values: Record<string, any>,
+    isPartial?: boolean,
+    stripe?: IStripe
+  ) => Promise<ISubmitResult | void>
 }
 
 function initStore(

--- a/packages/form-renderer/src/blocks/Form.tsx
+++ b/packages/form-renderer/src/blocks/Form.tsx
@@ -144,7 +144,7 @@ export const Form: FC<FormProps> = ({
         }
 
         // Submit form
-        await state.onSubmit?.(values, isPartialSubmission, state.stripe)
+        const submitResult = await state.onSubmit?.(values, isPartialSubmission, state.stripe)
 
         if (helper.isTrue(state.query.hideAfterSubmit)) {
           sendMessageToParent('HIDE_EMBED_MODAL')
@@ -172,7 +172,8 @@ export const Form: FC<FormProps> = ({
           type: 'setIsSubmitted',
           payload: {
             isSubmitted: true,
-            thankYouFieldId: thankYouFieldId || state.thankYouFields[0]?.id
+            thankYouFieldId: thankYouFieldId || state.thankYouFields[0]?.id,
+            pseudonymId: submitResult?.pseudonymId
           }
         })
 

--- a/packages/form-renderer/src/blocks/ThankYou.tsx
+++ b/packages/form-renderer/src/blocks/ThankYou.tsx
@@ -35,7 +35,15 @@ export const ThankYou: FC<BlockProps> = ({ field, className, children, ...restPr
         field={field}
         isScrollable={false}
         {...restProps}
-      />
+      >
+        {state.pseudonymId && (
+          <div className="heyform-pseudonym-id">
+            <span>Response ID:</span>
+            <strong>{state.pseudonymId}</strong>
+          </div>
+        )}
+        {children}
+      </Block>
       <WelcomeBranding />
     </>
   )

--- a/packages/form-renderer/src/store.ts
+++ b/packages/form-renderer/src/store.ts
@@ -115,6 +115,10 @@ export interface IStripe {
   accountId: string
 }
 
+export interface ISubmitResult {
+  pseudonymId?: string
+}
+
 export interface IState {
   formId: string
   instanceId: string
@@ -142,6 +146,7 @@ export interface IState {
   isSubmitTouched?: boolean
   isStarted?: boolean
   isSubmitted?: boolean
+  pseudonymId?: string
   isSidebarOpen?: boolean
   reportAbuseURL?: string
   locale: string
@@ -152,7 +157,11 @@ export interface IState {
   logo?: string
   theme: FormTheme
   stripe?: IStripe
-  onSubmit?: (values: Record<string, any>, isPartial?: boolean, stripe?: IStripe) => Promise<void>
+  onSubmit?: (
+    values: Record<string, any>,
+    isPartial?: boolean,
+    stripe?: IStripe
+  ) => Promise<ISubmitResult | void>
 }
 
 const actions: any = {
@@ -216,11 +225,12 @@ const actions: any = {
 
   setIsSubmitTouched: (state: IState, { isSubmitTouched }: any) => ({ ...state, isSubmitTouched }),
 
-  setIsSubmitted: (state: IState, { isSubmitted, thankYouFieldId }: any) => ({
+  setIsSubmitted: (state: IState, { isSubmitted, thankYouFieldId, pseudonymId }: any) => ({
     ...state,
     isSubmitted,
     isSidebarOpen: false,
-    thankYouFieldId
+    thankYouFieldId,
+    pseudonymId
   }),
 
   setIsSidebarOpen: (state: IState, { isSidebarOpen }: any) => ({ ...state, isSidebarOpen }),

--- a/packages/form-renderer/src/style.scss
+++ b/packages/form-renderer/src/style.scss
@@ -924,6 +924,14 @@ button.button-icon-only {
   }
 }
 
+.heyform-pseudonym-id {
+  @apply mt-6 flex items-baseline gap-2 text-lg;
+
+  strong {
+    @apply font-semibold tracking-wider;
+  }
+}
+
 .heyform-statement {
   .heyform-block-title,
   .heyform-block-description,

--- a/packages/form-renderer/src/views/Header.tsx
+++ b/packages/form-renderer/src/views/Header.tsx
@@ -13,7 +13,7 @@ export const Header: FC = () => {
 
   async function handleCountdownEnd() {
     // Submit form
-    await state.onSubmit?.(state.values, true)
+    const submitResult = await state.onSubmit?.(state.values, true)
 
     if (helper.isTrue(state.query.hideAfterSubmit)) {
       sendMessageToParent('HIDE_EMBED_MODAL')
@@ -22,7 +22,8 @@ export const Header: FC = () => {
     dispatch({
       type: 'setIsSubmitted',
       payload: {
-        isSubmitted: true
+        isSubmitted: true,
+        pseudonymId: submitResult?.pseudonymId
       }
     })
   }

--- a/packages/server/src/common/graphql/endpoint.graphql.ts
+++ b/packages/server/src/common/graphql/endpoint.graphql.ts
@@ -80,6 +80,9 @@ export class CompleteSubmissionInput {
 export class CompleteSubmissionType {
   @Field({ nullable: true })
   clientSecret?: string
+
+  @Field({ nullable: true })
+  pseudonymId?: string
 }
 
 @ObjectType()

--- a/packages/server/src/common/graphql/form.graphql.ts
+++ b/packages/server/src/common/graphql/form.graphql.ts
@@ -486,6 +486,10 @@ export class UpdateFormInput extends FormDetailInput {
 
   @Field({ nullable: true })
   @IsOptional()
+  generatePseudonymId?: boolean
+
+  @Field({ nullable: true })
+  @IsOptional()
   @MinLength(1)
   @MaxLength(128)
   password?: string
@@ -937,6 +941,9 @@ export class FormSettingType {
 
   @Field({ nullable: true })
   filterSpam?: boolean
+
+  @Field({ nullable: true })
+  generatePseudonymId?: boolean
 
   @Field({ nullable: true })
   allowArchive?: boolean

--- a/packages/server/src/common/graphql/submission.graphql.ts
+++ b/packages/server/src/common/graphql/submission.graphql.ts
@@ -146,6 +146,9 @@ export class SubmissionType {
   id: string
 
   @Field({ nullable: true })
+  pseudonymId?: string
+
+  @Field({ nullable: true })
   category: string
 
   @Field({ nullable: true })

--- a/packages/server/src/model/submission.model.ts
+++ b/packages/server/src/model/submission.model.ts
@@ -22,6 +22,9 @@ export class SubmissionModel extends Document {
   @Prop({ required: true, index: true })
   formId: string
 
+  @Prop()
+  pseudonymId?: string
+
   @Prop({
     type: String,
     required: true,
@@ -62,3 +65,13 @@ export class SubmissionModel extends Document {
 }
 
 export const SubmissionSchema = SchemaFactory.createForClass(SubmissionModel)
+
+SubmissionSchema.index(
+  { formId: 1, pseudonymId: 1 },
+  {
+    unique: true,
+    partialFilterExpression: {
+      pseudonymId: { $type: 'string' }
+    }
+  }
+)

--- a/packages/server/src/resolver/endpoint/complete-submission.resolver.ts
+++ b/packages/server/src/resolver/endpoint/complete-submission.resolver.ts
@@ -184,26 +184,38 @@ export class CompleteSubmissionResolver {
       form.settings.quotaLimit! > 0
         ? form.settings.quotaLimit
         : undefined
-    const submissionId = await this.submissionService.createWithinQuota(
-      {
-        teamId: form.teamId,
-        formId: form.id,
-        category,
-        title: form.name,
-        answers,
-        hiddenFields: normalizeSubmissionHiddenFields(form.hiddenFields, input.hiddenFields),
-        variables,
-        startAt,
-        endAt,
-        ip: client.ip,
-        userAgent: client.userAgent,
-        status
-      },
-      quotaLimit
-    )
+    const submission = {
+      teamId: form.teamId,
+      formId: form.id,
+      category,
+      title: form.name,
+      answers,
+      hiddenFields: normalizeSubmissionHiddenFields(form.hiddenFields, input.hiddenFields),
+      variables,
+      startAt,
+      endAt,
+      ip: client.ip,
+      userAgent: client.userAgent,
+      status
+    }
+    let submissionId: string
+    let pseudonymId: string | undefined
+
+    const settings = form.settings as typeof form.settings & { generatePseudonymId?: boolean }
+
+    if (settings.generatePseudonymId === true) {
+      const created = await this.submissionService.createWithPseudonymWithinQuota(
+        submission,
+        quotaLimit
+      )
+      submissionId = created.id
+      pseudonymId = created.pseudonymId
+    } else {
+      submissionId = await this.submissionService.createWithinQuota(submission, quotaLimit)
+    }
 
     // Payment
-    const result: CompleteSubmissionType = {}
+    const result: CompleteSubmissionType = { pseudonymId }
 
     if (helper.isValid(paymentAnswer) && helper.isValid(form.stripeAccount)) {
       result.clientSecret = await this.paymentService.createPaymentIntent({

--- a/packages/server/src/resolver/form/update-form.resolver.ts
+++ b/packages/server/src/resolver/form/update-form.resolver.ts
@@ -30,6 +30,7 @@ export class UpdateFormResolver {
       ['timeLimit', 'settings.timeLimit'],
       ['captchaKind', 'settings.captchaKind'],
       ['filterSpam', 'settings.filterSpam'],
+      ['generatePseudonymId', 'settings.generatePseudonymId'],
       ['enableQuotaLimit', 'settings.enableQuotaLimit'],
       ['quotaLimit', 'settings.quotaLimit'],
       ['enableIpLimit', 'settings.enableIpLimit'],

--- a/packages/server/src/service/export-file.service.ts
+++ b/packages/server/src/service/export-file.service.ts
@@ -13,6 +13,7 @@ import { helper, unixDate } from '@heyform-inc/utils'
 import { SubmissionModel } from '@model'
 
 const FIELD_ID_KEY = '#'
+const PSEUDONYM_ID_KEY = 'Pseudonym ID'
 const START_DATE_KEY = 'Start Date (UTC)'
 const SUBMIT_DATE_KEY = 'Submit Date (UTC)'
 const SPREADSHEET_FORMULA_PREFIXES = new Set(['=', '+', '-', '@'])
@@ -59,6 +60,10 @@ export class ExportFileService {
       {
         label: FIELD_ID_KEY,
         value: submission => submission.id
+      },
+      {
+        label: PSEUDONYM_ID_KEY,
+        value: submission => submission.pseudonymId || ''
       },
       ...selectedFormFields.map(field => ({
         label: field.title,

--- a/packages/server/src/service/submission.service.ts
+++ b/packages/server/src/service/submission.service.ts
@@ -3,17 +3,45 @@ import {
   SubmissionCategoryEnum,
   SubmissionStatusEnum
 } from '@heyform-inc/shared-types-enums'
-import { BadRequestException, Injectable } from '@nestjs/common'
+import { BadRequestException, Injectable, InternalServerErrorException } from '@nestjs/common'
 import { InjectModel } from '@nestjs/mongoose'
 import { Model } from 'mongoose'
 
 import { FormService } from './form.service'
 import { RedisService } from './redis.service'
-import { date, helper } from '@heyform-inc/utils'
+import { date, helper, nanoidCustomAlphabet } from '@heyform-inc/utils'
 import { SubmissionModel } from '@model'
 import { getUpdateQuery } from '@utils'
 
 const { isValid } = helper
+const PSEUDONYM_ID_ALPHABET = '23456789ABCDEFGHJKLMNPQRSTUVWXYZ'
+const PSEUDONYM_ID_LENGTH = 8
+const PSEUDONYM_ID_MAX_ATTEMPTS = 5
+
+export function generatePseudonymId(): string {
+  const value = nanoidCustomAlphabet(PSEUDONYM_ID_ALPHABET, PSEUDONYM_ID_LENGTH)
+  return `${value.slice(0, 4)}-${value.slice(4)}`
+}
+
+interface MongoDuplicateError {
+  code?: number
+  keyPattern?: Record<string, unknown>
+  keyValue?: Record<string, unknown>
+}
+
+function isPseudonymIdCollision(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false
+  }
+
+  const { code, keyPattern, keyValue } = error as MongoDuplicateError
+
+  return (
+    code === 11000 &&
+    (keyPattern?.pseudonymId === 1 ||
+      Object.prototype.hasOwnProperty.call(keyValue || {}, 'pseudonymId'))
+  )
+}
 
 interface FindSubmissionOptions {
   formId: string
@@ -280,6 +308,34 @@ export class SubmissionService {
 
       return this.create(submission)
     })
+  }
+
+  public async createWithPseudonymWithinQuota(
+    submission: SubmissionModel | Record<string, unknown>,
+    quotaLimit?: number,
+    generateId: () => string = generatePseudonymId
+  ): Promise<{ id: string; pseudonymId: string }> {
+    for (let attempt = 0; attempt < PSEUDONYM_ID_MAX_ATTEMPTS; attempt += 1) {
+      const pseudonymId = generateId()
+
+      try {
+        const id = await this.createWithinQuota(
+          {
+            ...submission,
+            pseudonymId
+          },
+          quotaLimit
+        )
+
+        return { id, pseudonymId }
+      } catch (error) {
+        if (!isPseudonymIdCollision(error)) {
+          throw error
+        }
+      }
+    }
+
+    throw new InternalServerErrorException('Failed to generate a unique pseudonym ID')
   }
 
   public async maskAsPrivate(formId: string, submissionIds?: string[]): Promise<boolean> {

--- a/packages/server/test/complete-submission-security.test.ts
+++ b/packages/server/test/complete-submission-security.test.ts
@@ -108,6 +108,8 @@ async function testPaymentUsesPublishedFormConfiguration() {
   )
 
   assert.strictEqual(result.clientSecret, 'client_secret_1')
+  assert.strictEqual(result.pseudonymId, undefined)
+  assert.strictEqual(storedSubmission?.pseudonymId, undefined)
   assert.strictEqual(paymentIntent?.amount, 4999)
   assert.strictEqual(paymentIntent?.currency, 'usd')
   assert.strictEqual(storedSubmission?.answers[0].value.amount, 4999)
@@ -170,9 +172,75 @@ async function testPaymentWebhookDoesNotRequireOrPersistClientSecret() {
   assert.strictEqual(updatedAnswer?.value.billingDetails.name, 'Respondent')
 }
 
+async function testPseudonymIdIsStoredAndReturned() {
+  let storedSubmission: Record<string, any> | undefined
+  const now = Math.floor(Date.now() / 1_000)
+  const form = {
+    id: 'form_1',
+    teamId: 'team_1',
+    name: 'Pseudonymized form',
+    suspended: false,
+    fields: [
+      {
+        id: 'question_1',
+        title: 'Answer',
+        kind: FieldKindEnum.SHORT_TEXT,
+        validations: { required: true }
+      }
+    ],
+    hiddenFields: [],
+    logics: [],
+    variables: [],
+    settings: {
+      active: true,
+      allowArchive: true,
+      captchaKind: CaptchaKindEnum.NONE,
+      generatePseudonymId: true
+    }
+  }
+  const resolver = new CompleteSubmissionResolver(
+    {
+      decryptToken: () => ({ formId: 'form_1', timestamp: now }),
+      assertOpenToken: () => now
+    } as any,
+    { findById: async () => form } as any,
+    {
+      createWithPseudonymWithinQuota: async (submission: Record<string, any>) => {
+        storedSubmission = submission
+        return { id: 'submission_1', pseudonymId: '7KQ2-9MX4' }
+      }
+    } as any,
+    {} as any,
+    { addQueue: () => undefined } as any,
+    { addQueue: () => undefined } as any,
+    {} as any
+  )
+
+  const result = await resolver.completeSubmission(
+    {
+      ip: '203.0.113.10',
+      deviceId: 'device_1',
+      lang: 'en',
+      userAgent: { browser: { name: 'Browser' } } as any
+    },
+    'anonymous_1',
+    {
+      formId: 'form_1',
+      answers: { question_1: 'Response' },
+      hiddenFields: [],
+      openToken: 'encrypted-token'
+    }
+  )
+
+  assert.strictEqual(result.pseudonymId, '7KQ2-9MX4')
+  assert.strictEqual(storedSubmission?.ip, '203.0.113.10')
+  assert.deepStrictEqual(storedSubmission?.userAgent, { browser: { name: 'Browser' } })
+}
+
 async function run() {
   await testPaymentUsesPublishedFormConfiguration()
   await testPaymentWebhookDoesNotRequireOrPersistClientSecret()
+  await testPseudonymIdIsStoredAndReturned()
 }
 
 if (require.main === module) {

--- a/packages/server/test/export-file.service.test.ts
+++ b/packages/server/test/export-file.service.test.ts
@@ -51,6 +51,7 @@ async function testExportsRepeatedQuestionTitlesByFieldId() {
     [
       {
         id: 'submission-1',
+        pseudonymId: '7KQ2-9MX4',
         answers: formFields.map((field, index) => ({
           id: field.id,
           kind: field.kind,
@@ -66,11 +67,18 @@ async function testExportsRepeatedQuestionTitlesByFieldId() {
 
   assert.deepStrictEqual(parseCsvRow(header), [
     '#',
+    'Pseudonym ID',
     ...formFields.map(field => field.title),
     'Start Date (UTC)',
     'Submit Date (UTC)'
   ])
-  assert.deepStrictEqual(parseCsvRow(row), ['submission-1', ...expectedAnswers, '', ''])
+  assert.deepStrictEqual(parseCsvRow(row), [
+    'submission-1',
+    '7KQ2-9MX4',
+    ...expectedAnswers,
+    '',
+    ''
+  ])
 }
 
 async function testExportsLegacyFileUploadUrls() {
@@ -107,6 +115,7 @@ async function testExportsLegacyFileUploadUrls() {
 
   assert.deepStrictEqual(parseCsvRow(row), [
     'submission-1',
+    '',
     'https://cdn.example.com/uploads/file-id',
     '',
     ''
@@ -176,6 +185,7 @@ async function testNeutralizesSpreadsheetFormulas() {
 
   assert.deepStrictEqual(parseCsvRow(header), [
     '#',
+    'Pseudonym ID',
     `'=1+1`,
     'Safe title',
     'Control-prefix formula',
@@ -185,6 +195,7 @@ async function testNeutralizesSpreadsheetFormulas() {
   ])
   assert.deepStrictEqual(parseCsvRow(row), [
     'submission-1',
+    '',
     `'=WEBSERVICE("https://attacker.test")`,
     `'  -1+1`,
     `'\u0000\u0007=1+1`,
@@ -223,7 +234,7 @@ async function testMalformedLegacyInputTableDoesNotBreakExport() {
   )
 
   const [, row] = csv.split(/\r?\n/)
-  assert.deepStrictEqual(parseCsvRow(row), ['submission-1', '', '', ''])
+  assert.deepStrictEqual(parseCsvRow(row), ['submission-1', '', '', '', ''])
 }
 
 async function run() {

--- a/packages/server/test/submission-quota.test.ts
+++ b/packages/server/test/submission-quota.test.ts
@@ -1,6 +1,57 @@
 import * as assert from 'assert'
 
-import { SubmissionService } from '../src/service/submission.service'
+import { SubmissionSchema } from '../src/model/submission.model'
+import { SubmissionService, generatePseudonymId } from '../src/service/submission.service'
+
+function testPseudonymIdFormat() {
+  for (let index = 0; index < 100; index += 1) {
+    assert.match(generatePseudonymId(), /^[2-9A-HJ-NP-Z]{4}-[2-9A-HJ-NP-Z]{4}$/)
+  }
+}
+
+function testPseudonymIdUniqueIndex() {
+  const index = SubmissionSchema.indexes().find(
+    ([fields]) => fields.formId === 1 && fields.pseudonymId === 1
+  )
+
+  assert.ok(index)
+  assert.strictEqual(index?.[1]?.unique, true)
+  assert.deepStrictEqual(index?.[1]?.partialFilterExpression, {
+    pseudonymId: { $type: 'string' }
+  })
+}
+
+async function testPseudonymIdCollisionIsRetried() {
+  const attemptedIds: string[] = []
+  const generatedIds = ['7KQ2-9MX4', 'ABCD-EFGH']
+  const model = {
+    create: async (submission: Record<string, any>) => {
+      attemptedIds.push(submission.pseudonymId)
+
+      if (attemptedIds.length === 1) {
+        throw {
+          code: 11000,
+          keyPattern: { formId: 1, pseudonymId: 1 },
+          keyValue: { formId: submission.formId, pseudonymId: submission.pseudonymId }
+        }
+      }
+
+      return { id: 'submission_1' }
+    }
+  }
+  const service = new SubmissionService(model as any, {} as any, {} as any)
+  const result = await service.createWithPseudonymWithinQuota(
+    { formId: 'form_1' },
+    undefined,
+    () => generatedIds.shift()!
+  )
+
+  assert.deepStrictEqual(attemptedIds, ['7KQ2-9MX4', 'ABCD-EFGH'])
+  assert.deepStrictEqual(result, {
+    id: 'submission_1',
+    pseudonymId: 'ABCD-EFGH'
+  })
+}
 
 async function testConcurrentCreatesCannotExceedQuota() {
   const submissions: Array<Record<string, any>> = []
@@ -44,6 +95,9 @@ async function testConcurrentCreatesCannotExceedQuota() {
 }
 
 async function run() {
+  testPseudonymIdFormat()
+  testPseudonymIdUniqueIndex()
+  await testPseudonymIdCollisionIsRetried()
   await testConcurrentCreatesCannotExceedQuota()
 }
 

--- a/packages/shared-types-enums/src/form.ts
+++ b/packages/shared-types-enums/src/form.ts
@@ -23,6 +23,7 @@ export interface FormSettings {
   published?: boolean
   allowArchive?: boolean
   filterSpam?: boolean
+  generatePseudonymId?: boolean
   password?: string
   requirePassword?: boolean
   // Move to "Thank You" settings

--- a/packages/shared-types-enums/src/submission.ts
+++ b/packages/shared-types-enums/src/submission.ts
@@ -22,6 +22,7 @@ export interface HiddenFieldAnswer extends HiddenField {
 export interface SubmissionModel {
   id: string
   formId: string
+  pseudonymId?: string
   category: SubmissionCategoryEnum
   title: string
   contact?: ContactModel

--- a/packages/webapp/src/consts/gql.ts
+++ b/packages/webapp/src/consts/gql.ts
@@ -145,6 +145,7 @@ export const WORKSPACE_RECENT_FORMS_GQL = gql`
         timeLimit
         filterSpam
         allowArchive
+        generatePseudonymId
         password
         requirePassword
         redirectOnCompletion
@@ -413,6 +414,7 @@ export const FORMS_GQL = gql`
         timeLimit
         filterSpam
         allowArchive
+        generatePseudonymId
         password
         requirePassword
         redirectOnCompletion
@@ -504,6 +506,7 @@ export const FORM_SUMMARY_GQL = gql`
         active
         filterSpam
         allowArchive
+        generatePseudonymId
         password
         requirePassword
         enableQuotaLimit
@@ -551,6 +554,7 @@ export const FORM_DETAIL_GQL = gql`
         timeLimit
         filterSpam
         allowArchive
+        generatePseudonymId
         password
         requirePassword
         enableQuotaLimit
@@ -622,6 +626,7 @@ export const COMPLETE_SUBMISSION_GQL = gql`
   mutation completeSubmission($input: CompleteSubmissionInput!) {
     completeSubmission(input: $input) {
       clientSecret
+      pseudonymId
     }
   }
 `
@@ -827,6 +832,7 @@ export const SUBMISSIONS_GQL = gql`
       total
       submissions {
         id
+        pseudonymId
         category
         title
         answers
@@ -1408,6 +1414,7 @@ export const PUBLIC_FORM_GQL = gql`
         timeLimit
         filterSpam
         allowArchive
+        generatePseudonymId
         password
         requirePassword
         enableQuotaLimit

--- a/packages/webapp/src/locales/de.json
+++ b/packages/webapp/src/locales/de.json
@@ -1131,6 +1131,10 @@
           "placeholder": "Geben Sie hier die Weiterleitungs-URL ein, z.B. https://example.com",
           "invalidUrl": "Die Weiterleitungs-URL ist ungültig"
         },
+        "pseudonymId": {
+          "headline": "Pseudonym-IDs",
+          "subHeadline": "Generieren Sie eine eindeutige Antwort-ID und zeigen Sie sie nach dem Absenden an."
+        },
         "progressBar": {
           "headline": "Fortschrittsbalken",
           "subHeadline": "Sie können den Befragten leicht mitteilen, wie nah sie daran sind, Ihr Formular abzuschließen."

--- a/packages/webapp/src/locales/en.json
+++ b/packages/webapp/src/locales/en.json
@@ -1193,6 +1193,10 @@
           "placeholder": "Enter the redirect URL here, e.g., https://example.com",
           "invalidUrl": "The redirect URL is not valid"
         },
+        "pseudonymId": {
+          "headline": "Pseudonym IDs",
+          "subHeadline": "Generate a unique response ID and show it after submission."
+        },
         "progressBar": {
           "headline": "Progress bar",
           "subHeadline": "You can easily let respondents know how close they are to completing your form."

--- a/packages/webapp/src/locales/fr.json
+++ b/packages/webapp/src/locales/fr.json
@@ -1135,6 +1135,10 @@
           "placeholder": "Entrez l'URL de redirection ici, par exemple, https://example.com",
           "invalidUrl": "L'URL de redirection n'est pas valide"
         },
+        "pseudonymId": {
+          "headline": "Identifiants pseudonymes",
+          "subHeadline": "Générez un identifiant de réponse unique et affichez-le après l'envoi."
+        },
         "progressBar": {
           "headline": "Barre de progression",
           "subHeadline": "Vous pouvez facilement informer les répondants de leur avancement dans le formulaire."

--- a/packages/webapp/src/locales/it.json
+++ b/packages/webapp/src/locales/it.json
@@ -1193,6 +1193,10 @@
           "placeholder": "Inserisci l'URL di reindirizzamento qui, es. https://esempio.com",
           "invalidUrl": "L'URL di reindirizzamento non è valido"
         },
+        "pseudonymId": {
+          "headline": "ID pseudonimi",
+          "subHeadline": "Genera un ID di risposta univoco e mostralo dopo l'invio."
+        },
         "progressBar": {
           "headline": "Barra di avanzamento",
           "subHeadline": "Fai sapere ai rispondenti quanto manca al completamento del modulo."

--- a/packages/webapp/src/locales/ja.json
+++ b/packages/webapp/src/locales/ja.json
@@ -1131,6 +1131,10 @@
           "placeholder": "ここにリダイレクトURLを入力してください。例：https://example.com",
           "invalidUrl": "無効なリダイレクトURL"
         },
+        "pseudonymId": {
+          "headline": "仮名ID",
+          "subHeadline": "一意の回答IDを生成し、送信後に表示します。"
+        },
         "progressBar": {
           "headline": "進捗バー",
           "subHeadline": "回答者がフォームの完了までどれくらいかを簡単に把握できるようにします。"

--- a/packages/webapp/src/locales/pl.json
+++ b/packages/webapp/src/locales/pl.json
@@ -1131,6 +1131,10 @@
           "placeholder": "Wprowadź tutaj URL przekierowania, np. https://example.com",
           "invalidUrl": "URL przekierowania jest nieprawidłowy"
         },
+        "pseudonymId": {
+          "headline": "Identyfikatory pseudonimowe",
+          "subHeadline": "Generuj unikalny identyfikator odpowiedzi i wyświetlaj go po przesłaniu."
+        },
         "progressBar": {
           "headline": "Pasek postępu",
           "subHeadline": "Możesz łatwo poinformować respondentów, jak blisko są ukończenia formularza."

--- a/packages/webapp/src/locales/pt-br.json
+++ b/packages/webapp/src/locales/pt-br.json
@@ -1193,6 +1193,10 @@
           "placeholder": "Insira a URL de redirecionamento aqui, por exemplo, https://example.com",
           "invalidUrl": "A URL de redirecionamento não é válida"
         },
+        "pseudonymId": {
+          "headline": "IDs de pseudônimo",
+          "subHeadline": "Gere um ID de resposta exclusivo e exiba-o após o envio."
+        },
         "progressBar": {
           "headline": "Barra de progresso",
           "subHeadline": "Você pode facilmente informar aos participantes o quão perto eles estão de preencher o formulário."

--- a/packages/webapp/src/locales/zh-cn.json
+++ b/packages/webapp/src/locales/zh-cn.json
@@ -1131,6 +1131,10 @@
           "placeholder": "在此处输入重定向 URL，例如：https://example.com",
           "invalidUrl": "重定向 URL 无效"
         },
+        "pseudonymId": {
+          "headline": "化名 ID",
+          "subHeadline": "生成唯一的回答 ID，并在提交后显示。"
+        },
         "progressBar": {
           "headline": "进度条",
           "subHeadline": "您可以轻松地让受访者了解他们离完成表单还有多远。"

--- a/packages/webapp/src/locales/zh-tw.json
+++ b/packages/webapp/src/locales/zh-tw.json
@@ -1131,6 +1131,10 @@
           "placeholder": "在此處輸入重定向 URL，例如：https://example.com",
           "invalidUrl": "重定向 URL 無效"
         },
+        "pseudonymId": {
+          "headline": "化名 ID",
+          "subHeadline": "產生唯一的回答 ID，並在提交後顯示。"
+        },
         "progressBar": {
           "headline": "進度條",
           "subHeadline": "您可以輕鬆地讓受訪者了解他們離完成表單還有多遠。"

--- a/packages/webapp/src/pages/form/Render/components/Renderer.tsx
+++ b/packages/webapp/src/pages/form/Render/components/Renderer.tsx
@@ -157,7 +157,7 @@ export const Renderer: FC<RendererProps> = ({ form, query, locale, contactId }) 
         })
         .filter(Boolean) as HiddenFieldAnswer[]
 
-      const { clientSecret } = await EndpointService.completeSubmission({
+      const { clientSecret, pseudonymId } = await EndpointService.completeSubmission({
         formId: form.id,
         contactId,
         answers: {
@@ -189,6 +189,8 @@ export const Renderer: FC<RendererProps> = ({ form, query, locale, contactId }) 
       }
 
       sendMessageToParent('FORM_SUBMITTED')
+
+      return { pseudonymId }
     } catch (err: Any) {
       /**
        * Throw error to let Renderer knows that there was an error.

--- a/packages/webapp/src/pages/form/Render/service/endpoint.ts
+++ b/packages/webapp/src/pages/form/Render/service/endpoint.ts
@@ -21,6 +21,7 @@ const UPLOAD_FILE_TOKEN_GQL = `mutation uploadFileToken($input: UploadFormFileIn
 const COMPLETE_SUBMISSION_GQL = `mutation completeSubmission($input: CompleteSubmissionInput!) {
 	completeSubmission(input: $input) {
 	  clientSecret
+	  pseudonymId
 	}
 }`
 
@@ -82,7 +83,7 @@ export class EndpointService {
     // Google reCAPTCHA token
     recaptchaToken?: string
     partialSubmission?: boolean
-  }): Promise<{ clientSecret?: string }> {
+  }): Promise<{ clientSecret?: string; pseudonymId?: string }> {
     const result = await axios({
       query: COMPLETE_SUBMISSION_GQL,
       variables: {

--- a/packages/webapp/src/pages/form/Settings/General.tsx
+++ b/packages/webapp/src/pages/form/Settings/General.tsx
@@ -22,6 +22,16 @@ export default function FormSettingsGeneral() {
 
         <Form.Item
           className="[&_[data-slot=content]]:pt-1.5"
+          name="generatePseudonymId"
+          label={t('form.settings.general.pseudonymId.headline')}
+          description={t('form.settings.general.pseudonymId.subHeadline')}
+          isInline
+        >
+          <Switch />
+        </Form.Item>
+
+        <Form.Item
+          className="[&_[data-slot=content]]:pt-1.5"
           name="enableProgress"
           label={t('form.settings.general.progressBar.headline')}
           description={t('form.settings.general.progressBar.subHeadline')}

--- a/packages/webapp/src/pages/form/Submissions/index.tsx
+++ b/packages/webapp/src/pages/form/Submissions/index.tsx
@@ -53,6 +53,8 @@ const SUBMISSION_CATEGORIES = [
   }
 ]
 
+const PSEUDONYM_ID_FIELD_ID = 'pseudonym_id'
+
 export default function FormSubmissions() {
   const { t } = useTranslation()
 
@@ -106,6 +108,11 @@ export default function FormSubmissions() {
   )
 
   const fields = useMemo(() => {
+    const pseudonymIdField = {
+      id: PSEUDONYM_ID_FIELD_ID,
+      kind: FieldKindEnum.SHORT_TEXT,
+      title: 'Pseudonym ID'
+    }
     const submitDateField = {
       id: FieldKindEnum.SUBMIT_DATE,
       kind: FieldKindEnum.SUBMIT_DATE,
@@ -128,7 +135,13 @@ export default function FormSubmissions() {
       title: row.name
     }))
 
-    return [submitDateField, ...questionFields, ...variables, ...hiddenFields] as FormField[]
+    return [
+      pseudonymIdField,
+      submitDateField,
+      ...questionFields,
+      ...variables,
+      ...hiddenFields
+    ] as FormField[]
   }, [form?.drafts, form?.hiddenFields, form?.variables, t])
 
   async function fetch({ current, pageSize }: TableFetchParams) {
@@ -143,6 +156,16 @@ export default function FormSubmissions() {
       ...row,
       answers: [
         ...row.answers,
+
+        ...(row.pseudonymId
+          ? [
+              {
+                id: PSEUDONYM_ID_FIELD_ID,
+                kind: FieldKindEnum.SHORT_TEXT,
+                value: row.pseudonymId
+              }
+            ]
+          : []),
 
         ...(row.variables || []).map(v => ({
           ...v,

--- a/packages/webapp/src/types/index.ts
+++ b/packages/webapp/src/types/index.ts
@@ -1,6 +1,8 @@
-import { FormField, FormModel } from '@heyform-inc/shared-types-enums'
+import { FormField, FormModel, SubmissionModel } from '@heyform-inc/shared-types-enums'
 
-export type { SubmissionModel as SubmissionType } from '@heyform-inc/shared-types-enums'
+export interface SubmissionType extends SubmissionModel {
+  pseudonymId?: string
+}
 
 export interface FormType extends Omit<FormModel, 'fields'> {
   drafts?: FormField[]


### PR DESCRIPTION
To support GDPR compliance, participants must be able to request the deletion of their data. This change implements the following mechanism: a pseudonymous ID is displayed on the “Thank you” page after submission and is associated with the participant’s response. By providing this ID, a participant can request that their submitted responses be deleted.