### PR TITLE
test(server): cover multiple-choice other text CSV export

### DIFF
--- a/packages/server/test/export-file.service.test.ts
+++ b/packages/server/test/export-file.service.test.ts
@@ -73,6 +73,47 @@ async function testExportsRepeatedQuestionTitlesByFieldId() {
   assert.deepStrictEqual(parseCsvRow(row), ['submission-1', ...expectedAnswers, '', ''])
 }
 
+async function testExportsMultipleChoiceOtherText() {
+  const formField: FormField = {
+    id: 'favorite-colors',
+    kind: FieldKindEnum.MULTIPLE_CHOICE,
+    title: 'Favorite colors',
+    properties: {
+      allowMultiple: true,
+      allowOther: true,
+      choices: [
+        { id: 'red', label: 'Red' },
+        { id: 'blue', label: 'Blue' }
+      ]
+    }
+  }
+  const csv = await new ExportFileService().csv(
+    [formField],
+    [],
+    [
+      {
+        id: 'submission-1',
+        answers: [
+          {
+            id: formField.id,
+            kind: formField.kind,
+            title: formField.title,
+            properties: formField.properties,
+            value: {
+              value: ['red'],
+              other: 'Chartreuse'
+            }
+          }
+        ],
+        hiddenFields: []
+      } as any
+    ]
+  )
+
+  const [, row] = csv.split(/\r?\n/)
+  assert.deepStrictEqual(parseCsvRow(row), ['submission-1', 'Red, Chartreuse', '', ''])
+}
+
 async function testExportsLegacyFileUploadUrls() {
   const csv = await new ExportFileService().csv(
     [
@@ -228,6 +269,7 @@ async function testMalformedLegacyInputTableDoesNotBreakExport() {
 
 async function run() {
   await testExportsRepeatedQuestionTitlesByFieldId()
+  await testExportsMultipleChoiceOtherText()
   await testExportsLegacyFileUploadUrls()
   await testNeutralizesSpreadsheetFormulas()
   await testMalformedLegacyInputTableDoesNotBreakExport()


### PR DESCRIPTION
## Summary

- add regression coverage for exporting multiple-choice answers that include custom Other text
- verify the CSV row includes both the selected choice label and the custom Other value

The current implementation already serializes this correctly on `main`; this keeps the issue scenario covered.

## Test plan

- `cd packages/server && pnpm exec ts-node --transpile-only -r tsconfig-paths/register test/export-file.service.test.ts`
- `pnpm exec prettier --check packages/server/test/export-file.service.test.ts`
- `git diff --check`

Refs #309
