### PR TITLE
fix(auth): set oauth state cookie maxage correctly

### DIFF
--- a/packages/server/src/service/auth.service.ts
+++ b/packages/server/src/service/auth.service.ts
@@ -21,6 +21,7 @@ import {
 import {
   helper,
   hs,
+  ms,
   isDateExpired,
   nanoid,
   parseNumber,
@@ -56,7 +57,7 @@ const DEFAULT_ATTEMPTS_OPTIONS = {
 }
 const NUMERIC_ALPHABET = '0123456789'
 const OAUTH_STATE_COOKIE_NAME = 'HEYFORM_OAUTH_STATE'
-const OAUTH_STATE_MAX_AGE = hs('10m')
+const OAUTH_STATE_MAX_AGE = ms('10m')
 const OAUTH_TRANSACTION_TTL = '10m'
 
 export interface OAuthTransaction {


### PR DESCRIPTION
The Set-Cookie header's Max-Age attribute takes a value in seconds, so Heyform's OAuth logic looked fine - but I couldn't log in!

It turns out Express' [cookie-session middleware](https://expressjs.com/en/resources/middleware/cookie-session/) takes maxAge in milliseconds. Swapping out `hs(OAUTH_STATE_MAX_AGE)` with `ms(OAUTH_STATE_MAX_AGE)` in `packages/server/src/service/auth.service.ts` sets the cookie for 10 minutes instead of 600 milliseconds, so OAuth/OIDC users can successfully log in.