### PR TITLE
feat(auth): custom oidc display icon url

### DIFF
--- a/packages/server/.env.example
+++ b/packages/server/.env.example
@@ -59,6 +59,7 @@ OIDC_CLIENT_ID=
 OIDC_CLIENT_SECRET=
 OIDC_ISSUER=
 OIDC_DISPLAY_NAME=SSO
+OIDC_DISPLAY_ICON_URL=
 # Must match the provider client registration: client_secret_basic or client_secret_post.
 OIDC_CLIENT_AUTH_METHOD=client_secret_basic
 # Allow a new OIDC identity to create an account when APP_DISABLE_REGISTRATION=true.

--- a/packages/server/src/controller/dashboard.controller.ts
+++ b/packages/server/src/controller/dashboard.controller.ts
@@ -10,6 +10,7 @@ import {
   ENABLE_GOOGLE_FONTS,
   GOOGLE_RECAPTCHA_KEY,
   OIDC_DISPLAY_NAME,
+  OIDC_DISPLAY_ICON_URL,
   STRIPE_PUBLISHABLE_KEY,
   VERIFY_EMAIL_RESEND_COOLDOWN
 } from '@environments'
@@ -30,7 +31,8 @@ export class DashboardController {
       uploadOrigins: TRUSTED_UPLOAD_ORIGINS,
       verifyEmailResendCooldownSeconds: Math.ceil(hs(VERIFY_EMAIL_RESEND_COOLDOWN) / 1000),
       disableLoginWithOidc: DISABLE_LOGIN_WITH_OIDC,
-      oidcDisplayName: OIDC_DISPLAY_NAME
+      oidcDisplayName: OIDC_DISPLAY_NAME,
+      oidcDisplayIconUrl: OIDC_DISPLAY_ICON_URL
     }
   }
 

--- a/packages/server/src/environments/index.ts
+++ b/packages/server/src/environments/index.ts
@@ -119,6 +119,7 @@ export const OIDC_CLIENT_ID: string = process.env.OIDC_CLIENT_ID
 export const OIDC_CLIENT_SECRET: string = process.env.OIDC_CLIENT_SECRET
 export const OIDC_ISSUER: string = process.env.OIDC_ISSUER
 export const OIDC_DISPLAY_NAME: string = process.env.OIDC_DISPLAY_NAME || 'SSO'
+export const OIDC_DISPLAY_ICON_URL: string = process.env.OIDC_DISPLAY_ICON_URL || ''
 export const OIDC_CLIENT_AUTH_METHOD = (process.env.OIDC_CLIENT_AUTH_METHOD ||
   'client_secret_basic') as 'client_secret_basic' | 'client_secret_post'
 export const OIDC_ALLOW_PROVISIONING: boolean = helper.isTrue(process.env.OIDC_ALLOW_PROVISIONING)

--- a/packages/webapp/src/consts/env.ts
+++ b/packages/webapp/src/consts/env.ts
@@ -34,6 +34,8 @@ export const DISABLE_LOGIN_WITH_OIDC = helper.isTrue(
 )
 export const OIDC_DISPLAY_NAME =
   window.heyform?.oidcDisplayName || (import.meta.env.VITE_OIDC_DISPLAY_NAME as string) || 'SSO'
+export const OIDC_DISPLAY_ICON_URL =
+  window.heyform?.oidcDisplayIconUrl || (import.meta.env.VITE_OIDC_DISPLAY_ICON_URL as string) || ''
 export const VERIFY_USER_EMAIL = helper.isTrue(
   window.heyform?.verifyUserEmail || import.meta.env.VITE_VERIFY_USER_EMAIL
 )

--- a/packages/webapp/src/pages/auth/SocialLogin.tsx
+++ b/packages/webapp/src/pages/auth/SocialLogin.tsx
@@ -11,6 +11,7 @@ import {
   DISABLE_LOGIN_WITH_GOOGLE,
   DISABLE_LOGIN_WITH_OIDC,
   OIDC_DISPLAY_NAME,
+  OIDC_DISPLAY_ICON_URL,
   isRegistrationDisabled
 } from '@/consts'
 
@@ -59,11 +60,13 @@ const SocialLogin: FC<SocialLoginProps> = ({ isSignUp }) => {
       ? {
           id: 'oidc',
           label: OIDC_DISPLAY_NAME,
-          icon: (
-            <SocialIcon>
-              <IconLock size={18} aria-hidden="true" className="shrink-0" color="currentColor" />
-            </SocialIcon>
-          )
+          icon: OIDC_DISPLAY_ICON_URL
+            ? <img src={OIDC_DISPLAY_ICON_URL} className="h-[18px] w-auto" alt="" />
+            : (
+              <SocialIcon>
+                <IconLock size={18} aria-hidden="true" className="shrink-0" color="currentColor" />
+              </SocialIcon>
+            )
         }
       : null
   ].filter(Boolean) as Array<{ id: string; label: string; icon: ReactNode }>


### PR DESCRIPTION
This adds an `OIDC_DISPLAY_ICON_URL` environment variable, to set a custom display icon on the OIDC log in button.

E.g.
<img width="415" height="497" alt="dyn-dda4afdc45ad64d3d75c9341de82276e" src="https://github.com/user-attachments/assets/a25ad3fa-fbe4-4b57-9734-8eb8d075a644" />

If it's unset, the icon falls back to the default padlock.